### PR TITLE
feat(worktree): implement git worktree detection and listing utilities

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,6 +21,28 @@ export interface Notification {
   type: NotificationType;
 }
 
+/**
+ * Represents a single git worktree.
+ * Git worktrees allow multiple working trees attached to the same repository,
+ * enabling work on different branches simultaneously.
+ */
+export interface Worktree {
+  /** Stable identifier for this worktree (normalized absolute path) */
+  id: string;
+
+  /** Absolute path to the worktree root directory */
+  path: string;
+
+  /** Human-readable name (branch name or last path segment) */
+  name: string;
+
+  /** Git branch name if available (undefined for detached HEAD) */
+  branch?: string;
+
+  /** Whether this is the currently active worktree based on cwd */
+  isCurrent: boolean;
+}
+
 export interface YellowwoodConfig {
   editor: string;
   editorArgs: string[];

--- a/src/utils/worktree.ts
+++ b/src/utils/worktree.ts
@@ -1,0 +1,209 @@
+import simpleGit, { SimpleGit } from 'simple-git';
+import path from 'path';
+import fs from 'fs';
+import type { Worktree } from '../types/index.js';
+
+/**
+ * Get all git worktrees for the repository containing cwd.
+ * Returns empty array if not a git repository or no worktrees.
+ *
+ * Uses `git worktree list --porcelain` which provides stable, machine-readable output.
+ *
+ * @param cwd - Current working directory (must be inside a git repository)
+ * @returns Array of Worktree objects, empty if not a git repo
+ *
+ * @example
+ * const worktrees = await getWorktrees('/Users/dev/project');
+ * // [
+ * //   { id: '/Users/dev/project', path: '/Users/dev/project',
+ * //     name: 'main', branch: 'main', isCurrent: false },
+ * //   { id: '/Users/dev/project-feature', path: '/Users/dev/project-feature',
+ * //     name: 'feature', branch: 'feature/auth', isCurrent: false }
+ * // ]
+ */
+export async function getWorktrees(cwd: string): Promise<Worktree[]> {
+  try {
+    const git: SimpleGit = simpleGit(cwd);
+
+    // Check if this is a git repository first
+    const isRepo = await git.checkIsRepo();
+    if (!isRepo) {
+      return [];
+    }
+
+    // Run git worktree list with porcelain format for stable parsing
+    const result = await git.raw(['worktree', 'list', '--porcelain']);
+
+    return parseWorktreeList(result);
+  } catch (error) {
+    // Git not installed or worktree command failed
+    // Only catch expected git errors - let programmer errors surface
+    if (error instanceof Error && (
+      error.message.includes('git') ||
+      error.message.includes('not found') ||
+      error.message.includes('command not found')
+    )) {
+      return [];
+    }
+    // Re-throw unexpected errors for debugging
+    throw error;
+  }
+}
+
+/**
+ * Identify which worktree contains the given cwd path.
+ * Matches by checking if cwd starts with any worktree path.
+ * Returns a copy of the matched worktree with isCurrent set to true.
+ *
+ * @param cwd - Current working directory to match
+ * @param worktrees - Array of worktrees to search
+ * @returns Matched worktree with isCurrent=true, or null if no match
+ *
+ * @example
+ * const current = getCurrentWorktree('/Users/dev/project/src', worktrees);
+ * // Returns worktree with path '/Users/dev/project' and isCurrent: true
+ */
+export function getCurrentWorktree(
+  cwd: string,
+  worktrees: Worktree[]
+): Worktree | null {
+  const normalizedCwd = normalizeWorktreePath(cwd);
+
+  // Find worktree that contains this cwd
+  // Important: Check longest paths first to handle nested worktrees correctly
+  const sorted = [...worktrees].sort((a, b) => b.path.length - a.path.length);
+
+  for (const wt of sorted) {
+    const normalizedWtPath = normalizeWorktreePath(wt.path);
+
+    // Check if cwd is within this worktree
+    if (normalizedCwd === normalizedWtPath || normalizedCwd.startsWith(normalizedWtPath + path.sep)) {
+      return { ...wt, isCurrent: true };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Parse output of `git worktree list --porcelain` into Worktree array.
+ *
+ * Porcelain format structure:
+ * ```
+ * worktree /absolute/path/to/worktree
+ * HEAD <commit-sha>
+ * branch refs/heads/branch-name
+ *
+ * worktree /absolute/path/to/another
+ * HEAD <commit-sha>
+ * detached
+ * ```
+ *
+ * @param output - Raw output from git worktree list --porcelain
+ * @returns Array of parsed Worktree objects
+ */
+function parseWorktreeList(output: string): Worktree[] {
+  const worktrees: Worktree[] = [];
+  const lines = output.trim().split(/\r?\n/);
+
+  let current: Partial<Worktree> = {};
+
+  for (const line of lines) {
+    if (line.startsWith('worktree ')) {
+      // Start of new worktree entry
+      // Save previous worktree if exists
+      if (current.path) {
+        worktrees.push(finalizeWorktree(current));
+      }
+
+      // Extract path (everything after "worktree ")
+      const worktreePath = line.substring(9);
+      current = { path: worktreePath };
+
+    } else if (line.startsWith('branch ')) {
+      // Extract branch name (strip refs/* prefixes for friendly names)
+      let branchName = line.substring(7);
+
+      // Strip common ref prefixes to show friendly names
+      if (branchName.startsWith('refs/heads/')) {
+        branchName = branchName.substring(11);
+      } else if (branchName.startsWith('refs/remotes/')) {
+        branchName = branchName.substring(13);
+      } else if (branchName.startsWith('refs/tags/')) {
+        branchName = branchName.substring(10);
+      }
+
+      current.branch = branchName;
+
+    } else if (line.startsWith('detached')) {
+      // Detached HEAD state - no branch
+      // current.branch remains undefined
+
+    } else if (line.startsWith('bare')) {
+      // Bare repository - rare in worktree context
+      // Note: bare repos typically don't have worktrees in the traditional sense
+
+    } else if (line.trim() === '') {
+      // Empty line separates worktrees
+      if (current.path) {
+        worktrees.push(finalizeWorktree(current));
+        current = {};
+      }
+    }
+    // Ignore other lines (HEAD, locked, prunable, etc.)
+  }
+
+  // Finalize last worktree if exists
+  if (current.path) {
+    worktrees.push(finalizeWorktree(current));
+  }
+
+  return worktrees;
+}
+
+/**
+ * Convert partial worktree data into complete Worktree object.
+ * Generates ID, name, and sets default values.
+ *
+ * @param partial - Partial worktree data from parsing
+ * @returns Complete Worktree object
+ */
+function finalizeWorktree(partial: Partial<Worktree>): Worktree {
+  if (!partial.path) {
+    throw new Error('Worktree path is required');
+  }
+
+  const worktreePath = partial.path;
+
+  // Generate stable ID from normalized absolute path
+  const id = normalizeWorktreePath(worktreePath);
+
+  // Generate human-readable name
+  // Prefer branch name, fall back to directory name
+  const name = partial.branch || path.basename(worktreePath);
+
+  return {
+    id,
+    path: worktreePath,
+    name,
+    branch: partial.branch,
+    isCurrent: false, // Will be set by getCurrentWorktree()
+  };
+}
+
+/**
+ * Normalize a worktree path for consistent comparison.
+ * Handles platform differences (Windows vs Unix paths) and resolves symlinks.
+ *
+ * @param worktreePath - Path to normalize
+ * @returns Normalized absolute path with symlinks resolved
+ */
+function normalizeWorktreePath(worktreePath: string): string {
+  try {
+    // Resolve symlinks and normalize path (e.g., /var -> /private/var on macOS)
+    return path.normalize(fs.realpathSync(worktreePath));
+  } catch (error) {
+    // If path doesn't exist yet, fall back to basic normalization
+    return path.normalize(path.resolve(worktreePath));
+  }
+}

--- a/tests/utils/worktree.test.ts
+++ b/tests/utils/worktree.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getWorktrees, getCurrentWorktree } from '../../src/utils/worktree.js';
+import type { Worktree } from '../../src/types/index.js';
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
+import { simpleGit, SimpleGit } from 'simple-git';
+
+describe('worktree utilities', () => {
+  let testRepoPath: string;
+  let git: SimpleGit;
+  let createdWorktrees: string[] = [];
+
+  beforeEach(async () => {
+    // Create temp directory for test repository
+    const tmpPath = path.join(os.tmpdir(), `yellowwood-worktree-test-${Date.now()}`);
+    await fs.ensureDir(tmpPath);
+    // Resolve symlinks (e.g., /var -> /private/var on macOS)
+    testRepoPath = await fs.realpath(tmpPath);
+
+    // Initialize git repository
+    git = simpleGit(testRepoPath);
+    await git.init();
+    await git.addConfig('user.name', 'Test User');
+    await git.addConfig('user.email', 'test@example.com');
+
+    // Create initial commit (required for worktrees)
+    await fs.writeFile(path.join(testRepoPath, 'README.md'), '# Test Repo');
+    await git.add('README.md');
+    await git.commit('Initial commit');
+
+    createdWorktrees = [];
+  });
+
+  afterEach(async () => {
+    // Clean up all created worktrees first
+    for (const wtPath of createdWorktrees) {
+      try {
+        await git.raw(['worktree', 'remove', '--force', wtPath]);
+        await fs.remove(wtPath);
+      } catch (error) {
+        // Worktree might already be removed, ignore errors
+      }
+    }
+
+    // Clean up temp directory
+    await fs.remove(testRepoPath);
+  });
+
+  describe('getWorktrees', () => {
+    it('returns single worktree for repository without additional worktrees', async () => {
+      const worktrees = await getWorktrees(testRepoPath);
+
+      expect(worktrees).toHaveLength(1);
+      expect(worktrees[0].path).toBe(testRepoPath);
+      expect(worktrees[0].branch).toBeDefined(); // Should have main or master
+      expect(worktrees[0].isCurrent).toBe(false); // Not set by getWorktrees
+    });
+
+    it('returns empty array for non-git directory', async () => {
+      const tmpPath = path.join(os.tmpdir(), `yellowwood-non-git-${Date.now()}`);
+      await fs.ensureDir(tmpPath);
+      const nonGitPath = await fs.realpath(tmpPath);
+
+      const worktrees = await getWorktrees(nonGitPath);
+
+      expect(worktrees).toEqual([]);
+
+      await fs.remove(nonGitPath);
+    });
+
+    it('detects multiple worktrees', async () => {
+      // Create a feature branch
+      await git.checkoutLocalBranch('feature/test');
+      await fs.writeFile(path.join(testRepoPath, 'feature.txt'), 'feature');
+      await git.add('feature.txt');
+      await git.commit('Add feature');
+
+      // Switch back to main/master
+      const branches = await git.branchLocal();
+      const mainBranch = branches.all.find(b => b === 'main' || b === 'master') || branches.all[0];
+      await git.checkout(mainBranch);
+
+      // Create worktree for feature branch
+      const tmpWtPath = path.join(os.tmpdir(), `yellowwood-wt-feature-${Date.now()}`);
+      await git.raw(['worktree', 'add', tmpWtPath, 'feature/test']);
+      // Resolve real path after git creates it
+      const worktreePath = await fs.realpath(tmpWtPath);
+      createdWorktrees.push(worktreePath);
+
+      const worktrees = await getWorktrees(testRepoPath);
+
+      expect(worktrees.length).toBeGreaterThanOrEqual(2);
+
+      // Main worktree
+      const mainWt = worktrees.find(wt => wt.path === testRepoPath);
+      expect(mainWt).toBeDefined();
+      expect(mainWt!.branch).toBeDefined();
+
+      // Feature worktree
+      const featureWt = worktrees.find(wt => wt.path === worktreePath);
+      expect(featureWt).toBeDefined();
+      expect(featureWt!.branch).toBe('feature/test');
+    });
+
+    it('handles worktree with detached HEAD', async () => {
+      // Get current commit hash
+      const log = await git.log({ maxCount: 1 });
+      const commitHash = log.latest?.hash;
+
+      if (!commitHash) {
+        throw new Error('Could not get commit hash');
+      }
+
+      // Create worktree with detached HEAD
+      const tmpWtPath = path.join(os.tmpdir(), `yellowwood-wt-detached-${Date.now()}`);
+      await git.raw(['worktree', 'add', '--detach', tmpWtPath, commitHash]);
+      // Resolve real path after git creates it
+      const worktreePath = await fs.realpath(tmpWtPath);
+      createdWorktrees.push(worktreePath);
+
+      const worktrees = await getWorktrees(testRepoPath);
+
+      const detachedWt = worktrees.find(wt => wt.path === worktreePath);
+      expect(detachedWt).toBeDefined();
+      expect(detachedWt!.branch).toBeUndefined(); // No branch in detached state
+      // Test that name falls back to directory basename for detached HEAD
+      expect(detachedWt!.name).toBe(path.basename(worktreePath));
+    });
+
+    it('generates stable IDs for worktrees', async () => {
+      const worktrees = await getWorktrees(testRepoPath);
+
+      expect(worktrees[0].id).toBeDefined();
+      expect(worktrees[0].id).toBe(path.normalize(path.resolve(testRepoPath)));
+    });
+
+    it('generates human-readable names', async () => {
+      const worktrees = await getWorktrees(testRepoPath);
+
+      expect(worktrees[0].name).toBeDefined();
+      // Name should be branch name or directory name
+      expect(typeof worktrees[0].name).toBe('string');
+      expect(worktrees[0].name.length).toBeGreaterThan(0);
+    });
+
+    it('works from subdirectory of repository', async () => {
+      // Create subdirectory
+      const subdir = path.join(testRepoPath, 'src', 'components');
+      await fs.ensureDir(subdir);
+
+      const worktrees = await getWorktrees(subdir);
+
+      expect(worktrees.length).toBeGreaterThan(0);
+      expect(worktrees[0].path).toBe(testRepoPath);
+    });
+  });
+
+  describe('getCurrentWorktree', () => {
+    it('identifies current worktree from cwd', async () => {
+      const worktrees = await getWorktrees(testRepoPath);
+      const current = getCurrentWorktree(testRepoPath, worktrees);
+
+      expect(current).not.toBeNull();
+      expect(current!.path).toBe(testRepoPath);
+      expect(current!.isCurrent).toBe(true);
+    });
+
+    it('matches worktree when cwd is subdirectory', async () => {
+      const subdir = path.join(testRepoPath, 'src', 'components');
+      await fs.ensureDir(subdir);
+
+      const worktrees = await getWorktrees(testRepoPath);
+      const current = getCurrentWorktree(subdir, worktrees);
+
+      expect(current).not.toBeNull();
+      expect(current!.path).toBe(testRepoPath);
+      expect(current!.isCurrent).toBe(true);
+    });
+
+    it('returns null when cwd is outside any worktree', async () => {
+      const worktrees = await getWorktrees(testRepoPath);
+      const outsidePath = '/tmp/completely/different/path';
+
+      const current = getCurrentWorktree(outsidePath, worktrees);
+
+      expect(current).toBeNull();
+    });
+
+    it('handles empty worktree array', async () => {
+      const current = getCurrentWorktree(testRepoPath, []);
+
+      expect(current).toBeNull();
+    });
+
+    it('prefers longer path matches for nested worktrees', async () => {
+      // Create nested worktree structure
+      const parentWt: Worktree = {
+        id: '/Users/dev/project',
+        path: '/Users/dev/project',
+        name: 'main',
+        branch: 'main',
+        isCurrent: false,
+      };
+
+      const nestedWt: Worktree = {
+        id: '/Users/dev/project/nested',
+        path: '/Users/dev/project/nested',
+        name: 'feature',
+        branch: 'feature/nested',
+        isCurrent: false,
+      };
+
+      const cwd = '/Users/dev/project/nested/src';
+      const current = getCurrentWorktree(cwd, [parentWt, nestedWt]);
+
+      // Should match nested worktree, not parent
+      expect(current).not.toBeNull();
+      expect(current!.path).toBe('/Users/dev/project/nested');
+    });
+
+    it('does not mutate original worktree array', async () => {
+      const worktrees = await getWorktrees(testRepoPath);
+      const originalWorktrees = JSON.parse(JSON.stringify(worktrees));
+
+      getCurrentWorktree(testRepoPath, worktrees);
+
+      expect(worktrees).toEqual(originalWorktrees);
+    });
+
+    it('returns null for path with similar prefix but different directory', async () => {
+      // Test that path matching doesn't give false positives
+      // e.g., /tmp/repo should not match /tmp/repo-old
+      const worktrees = await getWorktrees(testRepoPath);
+
+      // Try a path that shares a prefix but is a different directory
+      const similarPath = testRepoPath + '-different';
+
+      const current = getCurrentWorktree(similarPath, worktrees);
+
+      expect(current).toBeNull();
+    });
+
+    it('correctly identifies current worktree when cwd is symlink', async () => {
+      // Create a symlink to a subdirectory
+      const subdir = path.join(testRepoPath, 'src');
+      await fs.ensureDir(subdir);
+
+      const symlinkPath = path.join(os.tmpdir(), `yellowwood-symlink-${Date.now()}`);
+      await fs.symlink(subdir, symlinkPath);
+
+      try {
+        const worktrees = await getWorktrees(testRepoPath);
+        const current = getCurrentWorktree(symlinkPath, worktrees);
+
+        // Should match despite being called with symlink path
+        expect(current).not.toBeNull();
+        expect(current!.path).toBe(testRepoPath);
+        expect(current!.isCurrent).toBe(true);
+      } finally {
+        // Clean up symlink
+        await fs.remove(symlinkPath);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements git worktree detection and listing utilities to provide the foundational data layer for worktree-aware features.

Closes #4

## Changes Made
- Add Worktree interface to types with stable ID, path, name, branch, and isCurrent flag
- Implement getWorktrees() to detect all worktrees using git porcelain format
- Implement getCurrentWorktree() to identify active worktree from cwd
- Add cross-platform path normalization with symlink resolution
- Handle Windows CRLF line endings in git output
- Strip refs/* prefixes for friendly branch names (heads, remotes, tags)
- Implement comprehensive test suite with 15 tests covering edge cases

## Implementation Notes

### Context & Rationale
- Provides foundational data layer for worktree-aware features (switcher UI, header indicator, file watching)
- Enables Yellowwood to detect all worktrees in a repository and identify the currently active one
- Uses git's stable porcelain format for machine-readable parsing

### Implementation Details
- Added `Worktree` interface to `src/types/index.ts` with stable ID, path, name, branch, and isCurrent flag
- Implemented `getWorktrees()` using `git worktree list --porcelain` for stable output
- Implemented `getCurrentWorktree()` with longest-path-first matching for nested worktrees
- Cross-platform path normalization using `fs.realpathSync()` to handle macOS symlinks (/var -> /private/var) and Windows paths
- CRLF-safe parsing with `/\r?\n/` split to handle Windows line endings
- Improved error handling: checks `isRepo` first, only catches expected git errors, re-throws programmer errors for debugging
- Strips `refs/heads/`, `refs/remotes/`, and `refs/tags/` prefixes for friendly branch names in UI
- Comprehensive test suite with 15 tests covering edge cases: detached HEAD, nested worktrees, symlinks, path prefix false positives
- Guaranteed worktree cleanup in tests using tracked array in `afterEach`

## Follow-up Tasks
- Future: Consider caching normalized paths in Worktree object to avoid repeated realpathSync calls
- Future: Add integration with file watcher to detect worktree changes (Issue #11)
- Future: Add worktree switcher UI component (Issue #21, #24)