### PR TITLE
Implement clipboard operations

### DIFF
--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,0 +1,70 @@
+import clipboardy from 'clipboardy';
+import path from 'path';
+
+/**
+ * Copy text to the system clipboard.
+ *
+ * @param text - Text to copy to clipboard
+ * @throws Error if clipboard is unavailable or operation fails
+ */
+export async function copyToClipboard(text: string): Promise<void> {
+	try {
+		await clipboardy.write(text);
+	} catch (error) {
+		// Re-throw with more context
+		throw new Error(
+			`Failed to copy to clipboard: ${(error as Error).message}`
+		);
+	}
+}
+
+/**
+ * Copy a file path to the clipboard.
+ * Supports both relative and absolute paths.
+ *
+ * @param filePath - Absolute path to the file
+ * @param rootPath - Root directory path (for computing relative paths)
+ * @param relative - If true, copy relative path; if false, copy absolute path
+ * @throws Error if clipboard is unavailable or paths are invalid
+ */
+export async function copyFilePath(
+	filePath: string,
+	rootPath: string,
+	relative: boolean
+): Promise<void> {
+	// Validate inputs
+	if (!filePath.trim() || !rootPath.trim()) {
+		throw new Error('filePath and rootPath must not be empty');
+	}
+
+	// Normalize both paths
+	const normalizedFilePath = path.normalize(filePath);
+	const normalizedRootPath = path.normalize(rootPath);
+
+	// Validate that paths are absolute
+	if (!path.isAbsolute(normalizedFilePath) || !path.isAbsolute(normalizedRootPath)) {
+		throw new Error('filePath and rootPath must be absolute');
+	}
+
+	// Compute the path to copy
+	let pathToCopy = relative
+		? path.relative(normalizedRootPath, normalizedFilePath)
+		: normalizedFilePath;
+
+	// Handle relative path edge cases
+	if (relative) {
+		// Windows: Check for cross-drive scenario (different drive letters)
+		const fileDrive = path.parse(normalizedFilePath).root;
+		const rootDrive = path.parse(normalizedRootPath).root;
+		if (fileDrive !== rootDrive) {
+			// Fall back to absolute path when drives differ
+			pathToCopy = normalizedFilePath;
+		} else if (!pathToCopy) {
+			// When file equals root, relative path is empty - use '.' instead
+			pathToCopy = '.';
+		}
+	}
+
+	// Copy to clipboard
+	await copyToClipboard(pathToCopy);
+}

--- a/tests/utils/clipboard.test.ts
+++ b/tests/utils/clipboard.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { copyToClipboard, copyFilePath } from '../../src/utils/clipboard.js';
+import clipboardy from 'clipboardy';
+import path from 'path';
+
+// Mock clipboardy
+vi.mock('clipboardy', () => ({
+	default: {
+		write: vi.fn(),
+		read: vi.fn(),
+	},
+}));
+
+describe('clipboard utilities', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('copyToClipboard', () => {
+		it('copies text to clipboard', async () => {
+			const text = 'Hello, world!';
+			await copyToClipboard(text);
+
+			expect(clipboardy.write).toHaveBeenCalledWith(text);
+			expect(clipboardy.write).toHaveBeenCalledTimes(1);
+		});
+
+		it('copies empty string to clipboard', async () => {
+			await copyToClipboard('');
+
+			expect(clipboardy.write).toHaveBeenCalledWith('');
+		});
+
+		it('throws error if clipboard operation fails', async () => {
+			const error = new Error('Clipboard unavailable');
+			vi.mocked(clipboardy.write).mockRejectedValueOnce(error);
+
+			await expect(copyToClipboard('test')).rejects.toThrow(
+				'Failed to copy to clipboard: Clipboard unavailable'
+			);
+		});
+	});
+
+	describe('copyFilePath', () => {
+		it('copies absolute path when relative is false', async () => {
+			const filePath = '/Users/foo/project/src/App.tsx';
+			const rootPath = '/Users/foo/project';
+
+			await copyFilePath(filePath, rootPath, false);
+
+			// Should copy the absolute path (normalized)
+			expect(clipboardy.write).toHaveBeenCalledWith(
+				path.normalize(filePath)
+			);
+		});
+
+		it('copies relative path when relative is true', async () => {
+			const filePath = '/Users/foo/project/src/App.tsx';
+			const rootPath = '/Users/foo/project';
+
+			await copyFilePath(filePath, rootPath, true);
+
+			// Should copy relative path
+			expect(clipboardy.write).toHaveBeenCalledWith(
+				path.join('src', 'App.tsx')
+			);
+		});
+
+		it('handles relative paths for files at root level', async () => {
+			const filePath = '/Users/foo/project/README.md';
+			const rootPath = '/Users/foo/project';
+
+			await copyFilePath(filePath, rootPath, true);
+
+			expect(clipboardy.write).toHaveBeenCalledWith('README.md');
+		});
+
+		it('handles relative paths for files outside root', async () => {
+			const filePath = '/Users/bar/other/file.txt';
+			const rootPath = '/Users/foo/project';
+
+			await copyFilePath(filePath, rootPath, true);
+
+			// Should compute relative path going up and over
+			const expectedPath = path.relative(rootPath, filePath);
+			expect(clipboardy.write).toHaveBeenCalledWith(expectedPath);
+		});
+
+		it('normalizes paths before processing', async () => {
+			const filePath = '/Users/foo/project/src/../App.tsx';
+			const rootPath = '/Users/foo/project/';
+
+			await copyFilePath(filePath, rootPath, false);
+
+			// Should normalize (remove ..)
+			expect(clipboardy.write).toHaveBeenCalledWith(
+				path.normalize(filePath)
+			);
+		});
+
+		it('handles Windows-style paths on Windows', async () => {
+			// Mock path functions to handle Windows paths on any platform
+			const originalIsAbsolute = path.isAbsolute;
+			const originalParse = path.parse;
+			const originalRelative = path.relative;
+			const originalNormalize = path.normalize;
+
+			vi.spyOn(path, 'isAbsolute').mockImplementation((p: string) => {
+				// Treat Windows-style paths as absolute
+				if (p.match(/^[A-Z]:\\/)) return true;
+				return originalIsAbsolute(p);
+			});
+
+			vi.spyOn(path, 'parse').mockImplementation((p: string) => {
+				if (p.match(/^[A-Z]:\\/)) {
+					const match = p.match(/^([A-Z]:\\)/);
+					return { ...originalParse(p), root: match ? match[1] : 'C:\\' };
+				}
+				return originalParse(p);
+			});
+
+			vi.spyOn(path, 'relative').mockImplementation((from: string, to: string) => {
+				// Simple Windows path relative calculation
+				if (from.match(/^[A-Z]:\\/) && to.match(/^[A-Z]:\\/)) {
+					return 'src\\App.tsx';
+				}
+				return originalRelative(from, to);
+			});
+
+			vi.spyOn(path, 'normalize').mockImplementation((p: string) => {
+				if (p.match(/^[A-Z]:\\/)) return p;
+				return originalNormalize(p);
+			});
+
+			const filePath = 'C:\\Users\\foo\\project\\src\\App.tsx';
+			const rootPath = 'C:\\Users\\foo\\project';
+
+			await copyFilePath(filePath, rootPath, true);
+
+			// Should copy relative path with Windows separators
+			expect(clipboardy.write).toHaveBeenCalledWith('src\\App.tsx');
+
+			// Restore original implementations
+			vi.restoreAllMocks();
+		});
+
+		it('handles nested directories in relative paths', async () => {
+			const filePath = '/Users/foo/project/src/components/Button/index.tsx';
+			const rootPath = '/Users/foo/project';
+
+			await copyFilePath(filePath, rootPath, true);
+
+			expect(clipboardy.write).toHaveBeenCalledWith(
+				path.join('src', 'components', 'Button', 'index.tsx')
+			);
+		});
+
+		it('throws error if clipboard write fails', async () => {
+			const error = new Error('Permission denied');
+			vi.mocked(clipboardy.write).mockRejectedValueOnce(error);
+
+			const filePath = '/Users/foo/project/src/App.tsx';
+			const rootPath = '/Users/foo/project';
+
+			await expect(copyFilePath(filePath, rootPath, false)).rejects.toThrow(
+				'Failed to copy to clipboard'
+			);
+		});
+
+		it('handles file path same as root path', async () => {
+			const filePath = '/Users/foo/project';
+			const rootPath = '/Users/foo/project';
+
+			await copyFilePath(filePath, rootPath, true);
+
+			// Relative path from root to root returns '.' for clarity
+			expect(clipboardy.write).toHaveBeenCalledWith('.');
+		});
+	});
+
+	describe('validation', () => {
+		it('throws error for empty file path', async () => {
+			await expect(copyFilePath('', '/Users/foo/project', false)).rejects.toThrow(
+				'filePath and rootPath must not be empty'
+			);
+		});
+
+		it('throws error for empty root path', async () => {
+			await expect(copyFilePath('/Users/foo/project/src/App.tsx', '', false)).rejects.toThrow(
+				'filePath and rootPath must not be empty'
+			);
+		});
+
+		it('throws error for whitespace-only paths', async () => {
+			await expect(copyFilePath('   ', '/Users/foo/project', false)).rejects.toThrow(
+				'filePath and rootPath must not be empty'
+			);
+		});
+
+		it('throws error for relative file path', async () => {
+			await expect(copyFilePath('./src/App.tsx', '/Users/foo/project', false)).rejects.toThrow(
+				'filePath and rootPath must be absolute'
+			);
+		});
+
+		it('throws error for relative root path', async () => {
+			await expect(copyFilePath('/Users/foo/project/src/App.tsx', './project', false)).rejects.toThrow(
+				'filePath and rootPath must be absolute'
+			);
+		});
+
+		it('handles Windows cross-drive scenario by falling back to absolute path', async () => {
+			// Mock path functions to handle Windows paths on any platform
+			const originalIsAbsolute = path.isAbsolute;
+			const originalParse = path.parse;
+			const originalNormalize = path.normalize;
+
+			vi.spyOn(path, 'isAbsolute').mockImplementation((p: string) => {
+				// Treat Windows-style paths as absolute
+				if (p.match(/^[A-Z]:\\/)) return true;
+				return originalIsAbsolute(p);
+			});
+
+			vi.spyOn(path, 'parse').mockImplementation((p: string) => {
+				if (p.includes('C:')) {
+					return { ...originalParse(p), root: 'C:\\' };
+				} else if (p.includes('D:')) {
+					return { ...originalParse(p), root: 'D:\\' };
+				}
+				return originalParse(p);
+			});
+
+			vi.spyOn(path, 'normalize').mockImplementation((p: string) => {
+				if (p.match(/^[A-Z]:\\/)) return p;
+				return originalNormalize(p);
+			});
+
+			const filePath = 'D:\\Users\\bar\\file.txt';
+			const rootPath = 'C:\\Users\\foo\\project';
+
+			await copyFilePath(filePath, rootPath, true);
+
+			// Should fall back to absolute path when drives differ
+			expect(clipboardy.write).toHaveBeenCalledWith(filePath);
+
+			// Restore original implementations
+			vi.restoreAllMocks();
+		});
+	});
+
+	describe('edge cases', () => {
+		it('handles paths with spaces', async () => {
+			const filePath = '/Users/foo/My Project/src/App.tsx';
+			const rootPath = '/Users/foo/My Project';
+
+			await copyFilePath(filePath, rootPath, true);
+
+			expect(clipboardy.write).toHaveBeenCalledWith(
+				path.join('src', 'App.tsx')
+			);
+		});
+
+		it('handles paths with special characters', async () => {
+			const filePath = '/Users/foo/project/@types/index.d.ts';
+			const rootPath = '/Users/foo/project';
+
+			await copyFilePath(filePath, rootPath, true);
+
+			expect(clipboardy.write).toHaveBeenCalledWith(
+				path.join('@types', 'index.d.ts')
+			);
+		});
+
+		it('handles paths with unicode characters', async () => {
+			const filePath = '/Users/foo/project/文件/测试.txt';
+			const rootPath = '/Users/foo/project';
+
+			await copyFilePath(filePath, rootPath, true);
+
+			expect(clipboardy.write).toHaveBeenCalledWith(
+				path.join('文件', '测试.txt')
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Implements clipboard utilities for copying file paths to the system clipboard, supporting both absolute and relative path formats with robust cross-platform handling.

Closes #13

## Changes Made

- Add copyToClipboard() for generic text clipboard operations
- Add copyFilePath() for copying absolute/relative file paths
- Implement robust input validation (empty paths, absolute path requirements)
- Handle cross-platform edge cases (Windows cross-drive, path normalization)
- Create comprehensive test suite with 21 tests covering all scenarios

## Implementation Notes

**Context & rationale:**
- Provides clipboard utilities for copying file paths (absolute/relative) to system clipboard
- Uses clipboardy package for cross-platform clipboard access (macOS, Linux, Windows, WSL)
- Foundation for future keyboard shortcuts ('c' key) and context menu actions
- Designed for developer workflows: sharing paths with AI assistants, terminal commands, documentation

**Implementation details:**
- Created `src/utils/clipboard.ts` with two core functions:
  - `copyToClipboard(text)`: Low-level clipboard write wrapper with error handling
  - `copyFilePath(filePath, rootPath, relative)`: Copies absolute or relative file paths
- Implemented robust input validation:
  - Empty/whitespace path rejection
  - Absolute path requirement enforcement
  - Clear error messages for invalid inputs
- Handled cross-platform edge cases:
  - Windows cross-drive scenario (C:\ vs D:\) falls back to absolute path
  - Empty relative path (file === root) returns '.' instead of blank
  - Path normalization for consistent behavior
  - Platform-specific path separators handled by Node's path module
- Created comprehensive test suite (21 tests, 100% coverage):
  - Basic functionality (absolute/relative paths, nested directories)
  - Input validation (empty paths, relative paths, whitespace)
  - Error handling (clipboard failures, propagated errors)
  - Edge cases (spaces, special chars, unicode, same path)
  - Platform-specific scenarios (Windows paths, cross-drive)
- Applied Codex review feedback:
  - Added path validation before normalization
  - Fixed empty relative path to return '.'
  - Implemented Windows cross-drive fallback
  - Enhanced error messages with original error details
  - Added comprehensive validation tests

## Follow-up Tasks

- Wire keyboard shortcut ('c' key) to call copyFilePath in future issue
- Add context menu items ("Copy Path", "Copy Relative Path") in future issue
- Consider adding config option for default relative vs absolute preference
- Future enhancement: copy as file:// URL format for better IDE integration