### PR TITLE
feat(opener): implement configurable file opener system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "ink-select-input": "^6.2.0",
         "ink-spinner": "^5.0.0",
         "ink-text-input": "^6.0.0",
+        "minimatch": "^10.1.1",
         "react": "^19.2.0",
         "simple-git": "^3.30.0",
         "supports-hyperlinks": "^4.3.0",
@@ -757,6 +758,27 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -2915,6 +2937,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mrmime": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ink-select-input": "^6.2.0",
     "ink-spinner": "^5.0.0",
     "ink-text-input": "^6.0.0",
+    "minimatch": "^10.1.1",
     "react": "^19.2.0",
     "simple-git": "^3.30.0",
     "supports-hyperlinks": "^4.3.0",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,6 +43,25 @@ export interface Worktree {
   isCurrent: boolean;
 }
 
+export interface OpenerConfig {
+  /** Command to execute (editor name or path) */
+  cmd: string;
+
+  /** Arguments to pass to command */
+  args: string[];
+}
+
+export interface OpenersConfig {
+  /** Fallback opener used when no patterns match */
+  default: OpenerConfig;
+
+  /** Extension-based opener mapping */
+  byExtension: Record<string, OpenerConfig>;
+
+  /** Glob pattern-based opener mapping */
+  byGlob: Record<string, OpenerConfig>;
+}
+
 export interface YellowwoodConfig {
   editor: string;
   editorArgs: string[];
@@ -57,6 +76,7 @@ export interface YellowwoodConfig {
     format: string;
     asReference: boolean;
   };
+  openers?: OpenersConfig;
   autoRefresh: boolean;
   refreshDebounce: number;
   treeIndent: number;
@@ -101,6 +121,11 @@ export const DEFAULT_CONFIG: YellowwoodConfig = {
   copytreeDefaults: {
     format: 'xml',
     asReference: true,
+  },
+  openers: {
+    default: { cmd: 'code', args: ['-r'] },
+    byExtension: {},
+    byGlob: {},
   },
   autoRefresh: true,
   refreshDebounce: 100,

--- a/src/utils/fileOpener.ts
+++ b/src/utils/fileOpener.ts
@@ -1,0 +1,126 @@
+import { execa } from 'execa';
+import path from 'path';
+import { minimatch } from 'minimatch';
+import type { YellowwoodConfig, OpenerConfig } from '../types/index.js';
+
+/**
+ * Open a file using the configured opener.
+ * Matches file against opener patterns in order:
+ * 1. byExtension - exact extension match
+ * 2. byGlob - glob pattern match (first match wins)
+ * 3. default - fallback opener
+ *
+ * @param filePath - Absolute path to file to open
+ * @param config - Yellowwood configuration
+ * @throws Error if editor command fails or is not found
+ */
+export async function openFile(
+  filePath: string,
+  config: YellowwoodConfig
+): Promise<void> {
+  // Find the right opener for this file
+  const opener = resolveOpener(filePath, config);
+
+  // Build full command with args + filepath
+  const args = [...opener.args, filePath];
+
+  // Spawn editor process in detached mode
+  const child = execa(opener.cmd, args, {
+    detached: true,
+    stdio: 'ignore',
+    shell: false,
+    cleanup: false,
+  });
+
+  try {
+    // Wait only for spawn to succeed/fail, not for process to exit
+    await new Promise<void>((resolve, reject) => {
+      child.once('error', reject);  // ENOENT, EACCES, etc.
+      child.once('spawn', resolve); // Process started successfully
+    });
+
+    // Process started successfully - detach it and return immediately
+    child.unref();
+
+    // Optionally swallow non-zero exit codes since we don't care about editor exit status
+    child.catch(() => {});
+  } catch (error) {
+    // Enhance error message with helpful context
+    const err = error as Error & { code?: string };
+    if (err.code === 'ENOENT') {
+      throw new Error(
+        `Editor '${opener.cmd}' not found. Please install it or update your config.`
+      );
+    } else if (err.code === 'EACCES') {
+      throw new Error(
+        `Permission denied executing '${opener.cmd}'. Check file permissions.`
+      );
+    } else {
+      throw new Error(
+        `Failed to open file with '${opener.cmd}': ${err.message}`
+      );
+    }
+  }
+}
+
+/**
+ * Find the appropriate opener for a file based on config.
+ * Checks in order: byExtension, byGlob, default.
+ *
+ * @param filePath - Path to file
+ * @param config - Yellowwood configuration
+ * @returns OpenerConfig to use
+ */
+function resolveOpener(filePath: string, config: YellowwoodConfig): OpenerConfig {
+  const openers = config.openers;
+
+  // Handle case where openers not configured - fall back to editor/editorArgs
+  if (!openers) {
+    return {
+      cmd: config.editor,
+      args: config.editorArgs,
+    };
+  }
+
+  // 1. Check extension-based openers (case-insensitive)
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext && openers.byExtension) {
+    // Normalize extension keys to lowercase for case-insensitive matching
+    const normalizedByExtension: Record<string, OpenerConfig> = {};
+    for (const [key, value] of Object.entries(openers.byExtension)) {
+      normalizedByExtension[key.toLowerCase()] = value;
+    }
+
+    if (normalizedByExtension[ext]) {
+      return normalizedByExtension[ext];
+    }
+  }
+
+  // 2. Check glob-based openers (first match wins)
+  if (openers.byGlob) {
+    // Use deterministic iteration order (Object.entries maintains insertion order)
+    for (const [pattern, opener] of Object.entries(openers.byGlob)) {
+      if (matchesGlob(filePath, pattern)) {
+        return opener;
+      }
+    }
+  }
+
+  // 3. Fall back to default opener
+  return openers.default;
+}
+
+/**
+ * Check if a file path matches a glob pattern.
+ * Uses minimatch for glob matching.
+ *
+ * @param filePath - File path to test
+ * @param pattern - Glob pattern
+ * @returns true if path matches pattern
+ */
+function matchesGlob(filePath: string, pattern: string): boolean {
+  return minimatch(filePath, pattern, {
+    dot: true,        // Match dotfiles
+    matchBase: true,  // Match basename if no slashes in pattern
+  });
+}

--- a/tests/utils/fileOpener.test.ts
+++ b/tests/utils/fileOpener.test.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { openFile } from '../../src/utils/fileOpener.js';
+import { DEFAULT_CONFIG } from '../../src/types/index.js';
+import type { YellowwoodConfig } from '../../src/types/index.js';
+import * as execa from 'execa';
+
+// Mock execa
+vi.mock('execa', () => ({
+  execa: vi.fn(),
+}));
+
+describe('openFile', () => {
+  const mockExeca = vi.mocked(execa.execa);
+
+  beforeEach(() => {
+    mockExeca.mockReset();
+    // Mock execa to return a child process with event emitter methods
+    mockExeca.mockReturnValue({
+      once: vi.fn((event: string, handler: Function) => {
+        if (event === 'spawn') {
+          // Simulate successful spawn
+          setTimeout(() => handler(), 0);
+        }
+      }),
+      unref: vi.fn(),
+      catch: vi.fn(),
+    } as any);
+  });
+
+  it('uses default opener when no patterns match', async () => {
+    const config: YellowwoodConfig = {
+      ...DEFAULT_CONFIG,
+      openers: {
+        default: { cmd: 'code', args: ['-r'] },
+        byExtension: {},
+        byGlob: {},
+      },
+    };
+
+    await openFile('/path/to/file.txt', config);
+
+    expect(mockExeca).toHaveBeenCalledWith(
+      'code',
+      ['-r', '/path/to/file.txt'],
+      expect.objectContaining({ detached: true, stdio: 'ignore' })
+    );
+  });
+
+  it('uses extension-based opener when extension matches', async () => {
+    const config: YellowwoodConfig = {
+      ...DEFAULT_CONFIG,
+      openers: {
+        default: { cmd: 'code', args: ['-r'] },
+        byExtension: {
+          '.log': { cmd: 'less', args: ['+G'] },
+        },
+        byGlob: {},
+      },
+    };
+
+    await openFile('/var/log/app.log', config);
+
+    expect(mockExeca).toHaveBeenCalledWith(
+      'less',
+      ['+G', '/var/log/app.log'],
+      expect.objectContaining({ detached: true })
+    );
+  });
+
+  it('uses glob-based opener when path matches pattern', async () => {
+    const config: YellowwoodConfig = {
+      ...DEFAULT_CONFIG,
+      openers: {
+        default: { cmd: 'code', args: ['-r'] },
+        byExtension: {},
+        byGlob: {
+          '**/tests/**/*.ts': { cmd: 'vitest', args: ['run'] },
+        },
+      },
+    };
+
+    await openFile('/project/tests/unit/foo.ts', config);
+
+    expect(mockExeca).toHaveBeenCalledWith(
+      'vitest',
+      ['run', '/project/tests/unit/foo.ts'],
+      expect.objectContaining({ detached: true })
+    );
+  });
+
+  it('prefers extension match over glob match', async () => {
+    const config: YellowwoodConfig = {
+      ...DEFAULT_CONFIG,
+      openers: {
+        default: { cmd: 'code', args: [] },
+        byExtension: {
+          '.ts': { cmd: 'vim', args: [] },
+        },
+        byGlob: {
+          '**/*.ts': { cmd: 'nano', args: [] },
+        },
+      },
+    };
+
+    await openFile('/project/file.ts', config);
+
+    // Should use extension match (vim), not glob match (nano)
+    expect(mockExeca).toHaveBeenCalledWith(
+      'vim',
+      ['/project/file.ts'],
+      expect.any(Object)
+    );
+  });
+
+  it('uses first matching glob pattern', async () => {
+    const config: YellowwoodConfig = {
+      ...DEFAULT_CONFIG,
+      openers: {
+        default: { cmd: 'code', args: [] },
+        byExtension: {},
+        byGlob: {
+          '**/src/*.ts': { cmd: 'editor1', args: [] },
+          '**/*.ts': { cmd: 'editor2', args: [] },
+        },
+      },
+    };
+
+    await openFile('/project/src/file.ts', config);
+
+    // Should use first match (editor1)
+    expect(mockExeca).toHaveBeenCalledWith(
+      'editor1',
+      ['/project/src/file.ts'],
+      expect.any(Object)
+    );
+  });
+
+  it('falls back to editor/editorArgs when openers not configured', async () => {
+    const config: YellowwoodConfig = {
+      ...DEFAULT_CONFIG,
+      editor: 'vim',
+      editorArgs: ['-n'],
+      // openers not set
+    };
+    delete config.openers;
+
+    await openFile('/path/to/file.txt', config);
+
+    expect(mockExeca).toHaveBeenCalledWith(
+      'vim',
+      ['-n', '/path/to/file.txt'],
+      expect.any(Object)
+    );
+  });
+
+  it('throws helpful error when editor not found', async () => {
+    mockExeca.mockReturnValue({
+      once: vi.fn((event: string, handler: Function) => {
+        if (event === 'error') {
+          // Simulate ENOENT error
+          setTimeout(() => handler({ code: 'ENOENT', message: 'not found' }), 0);
+        }
+      }),
+      unref: vi.fn(),
+      catch: vi.fn(),
+    } as any);
+
+    const config: YellowwoodConfig = {
+      ...DEFAULT_CONFIG,
+      openers: {
+        default: { cmd: 'nonexistent', args: [] },
+        byExtension: {},
+        byGlob: {},
+      },
+    };
+
+    await expect(openFile('/file.txt', config)).rejects.toThrow(
+      "Editor 'nonexistent' not found"
+    );
+  });
+
+  it('throws helpful error when permission denied', async () => {
+    mockExeca.mockReturnValue({
+      once: vi.fn((event: string, handler: Function) => {
+        if (event === 'error') {
+          // Simulate EACCES error
+          setTimeout(() => handler({ code: 'EACCES', message: 'permission denied' }), 0);
+        }
+      }),
+      unref: vi.fn(),
+      catch: vi.fn(),
+    } as any);
+
+    const config: YellowwoodConfig = {
+      ...DEFAULT_CONFIG,
+      openers: {
+        default: { cmd: 'editor', args: [] },
+        byExtension: {},
+        byGlob: {},
+      },
+    };
+
+    await expect(openFile('/file.txt', config)).rejects.toThrow(
+      "Permission denied executing 'editor'"
+    );
+  });
+
+  it('passes file path as last argument', async () => {
+    const config: YellowwoodConfig = {
+      ...DEFAULT_CONFIG,
+      openers: {
+        default: { cmd: 'editor', args: ['--flag1', '--flag2'] },
+        byExtension: {},
+        byGlob: {},
+      },
+    };
+
+    await openFile('/path/to/file.txt', config);
+
+    expect(mockExeca).toHaveBeenCalledWith(
+      'editor',
+      ['--flag1', '--flag2', '/path/to/file.txt'],
+      expect.any(Object)
+    );
+  });
+
+  it('handles files without extensions', async () => {
+    const config: YellowwoodConfig = {
+      ...DEFAULT_CONFIG,
+      openers: {
+        default: { cmd: 'code', args: [] },
+        byExtension: {
+          '.txt': { cmd: 'nano', args: [] },
+        },
+        byGlob: {},
+      },
+    };
+
+    await openFile('/path/to/Makefile', config);
+
+    // Should use default (no extension match)
+    expect(mockExeca).toHaveBeenCalledWith(
+      'code',
+      ['/path/to/Makefile'],
+      expect.any(Object)
+    );
+  });
+
+  it('matches glob patterns with dots', async () => {
+    const config: YellowwoodConfig = {
+      ...DEFAULT_CONFIG,
+      openers: {
+        default: { cmd: 'code', args: [] },
+        byExtension: {},
+        byGlob: {
+          '.*rc': { cmd: 'vim', args: [] },
+        },
+      },
+    };
+
+    await openFile('/home/user/.bashrc', config);
+
+    expect(mockExeca).toHaveBeenCalledWith(
+      'vim',
+      ['/home/user/.bashrc'],
+      expect.any(Object)
+    );
+  });
+
+  it('matches hidden files with wildcard patterns via dot option', async () => {
+    const config: YellowwoodConfig = {
+      ...DEFAULT_CONFIG,
+      openers: {
+        default: { cmd: 'code', args: [] },
+        byExtension: {},
+        byGlob: {
+          '*.env': { cmd: 'vim', args: [] },
+        },
+      },
+    };
+
+    await openFile('/home/user/.env', config);
+
+    // Should match hidden .env file due to dot:true in minimatch
+    expect(mockExeca).toHaveBeenCalledWith(
+      'vim',
+      ['/home/user/.env'],
+      expect.any(Object)
+    );
+  });
+
+  it('handles case-insensitive extension matching', async () => {
+    const config: YellowwoodConfig = {
+      ...DEFAULT_CONFIG,
+      openers: {
+        default: { cmd: 'code', args: [] },
+        byExtension: {
+          '.md': { cmd: 'typora', args: [] },
+        },
+        byGlob: {},
+      },
+    };
+
+    // Test with uppercase extension
+    await openFile('/path/to/README.MD', config);
+
+    // Should match .md opener despite uppercase extension
+    expect(mockExeca).toHaveBeenCalledWith(
+      'typora',
+      ['/path/to/README.MD'],
+      expect.any(Object)
+    );
+  });
+
+  it('calls execa with detached and cleanup options', async () => {
+    const config: YellowwoodConfig = {
+      ...DEFAULT_CONFIG,
+      openers: {
+        default: { cmd: 'code', args: [] },
+        byExtension: {},
+        byGlob: {},
+      },
+    };
+
+    await openFile('/file.txt', config);
+
+    expect(mockExeca).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Array),
+      expect.objectContaining({
+        detached: true,
+        stdio: 'ignore',
+        shell: false,
+        cleanup: false,
+      })
+    );
+  });
+
+  it('handles other errors with context', async () => {
+    mockExeca.mockReturnValue({
+      once: vi.fn((event: string, handler: Function) => {
+        if (event === 'error') {
+          // Simulate generic error
+          setTimeout(() => handler({ message: 'Some other error' }), 0);
+        }
+      }),
+      unref: vi.fn(),
+      catch: vi.fn(),
+    } as any);
+
+    const config: YellowwoodConfig = {
+      ...DEFAULT_CONFIG,
+      openers: {
+        default: { cmd: 'myeditor', args: [] },
+        byExtension: {},
+        byGlob: {},
+      },
+    };
+
+    await expect(openFile('/file.txt', config)).rejects.toThrow(
+      "Failed to open file with 'myeditor': Some other error"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Implements a configurable file opener system with pattern-based matching (extension, glob, default fallback). Uses execa for cross-platform process spawning to launch files in configured editors without blocking the TUI.

Closes #12

## Changes Made

- Add OpenerConfig and OpenersConfig types for pattern-based matching
- Implement three-tier opener resolution: extension → glob → default
- Add minimatch dependency for glob pattern matching
- Support case-insensitive extension matching
- Implement detached process spawning with spawn event handling
- Add comprehensive config validation for opener structure
- Deep merge openers across global and project configs
- Add 16 file opener tests and 13 config validation tests

## Implementation Notes

**Context & Rationale:**
- Yellowwood needs configurable file opening to support diverse workflows (different editors for different file types)
- Pattern-based matching enables power users to configure extension-based and glob-based openers
- Cross-platform process spawning via execa ensures editors work on Windows/macOS/Linux
- Detached process spawning prevents TUI from blocking while editor is open

**Implementation Details:**
- Added OpenerConfig and OpenersConfig types to centralize opener configuration
- Implemented three-tier matching precedence: extension → glob → default
- Used minimatch for glob pattern matching with dot:true to match hidden files
- Extension matching is case-insensitive (README.MD matches .md opener)
- Process spawning waits only for spawn event (not process exit) via event listeners
- Config validation checks cmd/args structure and validates each arg element is a string
- Deep merging for openers preserves both global and project-level patterns

## Breaking Changes & Migration Hints

**Breaking Changes:**
- None - openers field is optional for backward compatibility with existing configs

**Migration Hints:**
- Users can migrate from simple `editor`/`editorArgs` to extended `openers` config for advanced use cases
- Existing configs without `openers` continue to work using `editor` and `editorArgs` fields

## Follow-up Tasks

- Consider adding opener aliases (e.g., "vscode" → "code") for common editor names
- Could add async opener validation at startup to warn about missing editors
- Future: "Open with..." context menu could leverage this opener system