### PR TITLE
feat(header): add worktree display with clickable navigation

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,23 +1,85 @@
 import React from 'react';
-import { Box, Text } from 'ink';
+import { Box, Text, useInput } from 'ink';
+import { relative } from 'node:path';
+import type { Worktree } from '../types/index.js';
 
 interface HeaderProps {
   cwd: string;
   filterActive: boolean;
   filterQuery: string;
+  currentWorktree?: Worktree | null;
+  worktreeCount?: number;
+  onWorktreeClick?: () => void;
 }
 
-export const Header: React.FC<HeaderProps> = ({ cwd, filterActive, filterQuery }) => {
+export const Header: React.FC<HeaderProps> = ({
+  cwd,
+  filterActive,
+  filterQuery,
+  currentWorktree,
+  worktreeCount = 0,
+  onWorktreeClick,
+}) => {
+  // Handle keyboard input for worktree panel (w key)
+  // Only trigger when filter is not active to avoid intercepting filter input
+  useInput((input, key) => {
+    if (!filterActive && input === 'w' && onWorktreeClick && currentWorktree) {
+      onWorktreeClick();
+    }
+  });
+
+  // Determine worktree display name - use branch, then name, then 'detached'
+  const worktreeName = currentWorktree?.branch ?? currentWorktree?.name ?? 'detached';
+
+  // Show worktree indicator when we have worktree data
+  const showWorktreeIndicator = !!currentWorktree;
+
+  // Format relative path (show cwd relative to worktree root if possible)
+  const displayPath = currentWorktree
+    ? (() => {
+        const rel = relative(currentWorktree.path, cwd);
+        // If cwd is the worktree root, relative returns '.'
+        if (rel === '.') return '/';
+        // If cwd is outside worktree, relative returns '..' path - use absolute
+        if (rel.startsWith('..')) return cwd;
+        // Otherwise, prepend '/' to make it clear it's relative to root
+        return `/${rel}`;
+      })()
+    : cwd;
+
+  // Truncate long branch names
+  const maxBranchLength = 20;
+  const truncatedBranchName = worktreeName.length > maxBranchLength
+    ? worktreeName.slice(0, maxBranchLength - 1) + '…'
+    : worktreeName;
+
   return (
     <Box borderStyle="single" paddingX={1}>
       <Text bold>Yellowwood</Text>
-      <Text dimColor> - </Text>
-      <Text>{cwd}</Text>
+
+      {showWorktreeIndicator && (
+        <>
+          <Text dimColor> • </Text>
+          <Text dimColor>wt </Text>
+          <Text
+            color="cyan"
+            bold={onWorktreeClick !== undefined}
+            underline={onWorktreeClick !== undefined}
+          >
+            [{truncatedBranchName}]
+          </Text>
+          <Text dimColor> ({worktreeCount})</Text>
+        </>
+      )}
+
+      <Text dimColor> • </Text>
+      <Text>{displayPath}</Text>
+
       {filterActive && (
         <>
           <Text dimColor> [</Text>
           <Text color="yellow">*</Text>
-          <Text dimColor>] Filter: </Text>
+          <Text dimColor>] </Text>
           <Text color="cyan">{filterQuery}</Text>
         </>
       )}

--- a/tests/components/Header.test.tsx
+++ b/tests/components/Header.test.tsx
@@ -1,0 +1,469 @@
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { describe, it, expect, vi } from 'vitest';
+import { Header } from '../../src/components/Header.js';
+import type { Worktree } from '../../src/types/index.js';
+
+describe('Header', () => {
+  const mockWorktree: Worktree = {
+    id: '/Users/dev/project',
+    path: '/Users/dev/project',
+    name: 'main',
+    branch: 'main',
+    isCurrent: true,
+  };
+
+  describe('basic rendering', () => {
+    it('renders app name and cwd without worktree info', () => {
+      const { lastFrame } = render(
+        <Header
+          cwd="/Users/dev/project"
+          filterActive={false}
+          filterQuery=""
+        />
+      );
+
+      const output = lastFrame();
+      expect(output).toContain('Yellowwood');
+      expect(output).toContain('/Users/dev/project');
+      expect(output).not.toContain('wt'); // No worktree indicator
+    });
+
+    it('renders worktree indicator when currentWorktree provided', () => {
+      const { lastFrame } = render(
+        <Header
+          cwd="/Users/dev/project"
+          filterActive={false}
+          filterQuery=""
+          currentWorktree={mockWorktree}
+          worktreeCount={3}
+        />
+      );
+
+      const output = lastFrame();
+      expect(output).toContain('Yellowwood');
+      expect(output).toContain('wt');
+      expect(output).toContain('[main]');
+      expect(output).toContain('(3)');
+    });
+
+    it('shows relative path when in worktree subdirectory', () => {
+      const { lastFrame } = render(
+        <Header
+          cwd="/Users/dev/project/src/components"
+          filterActive={false}
+          filterQuery=""
+          currentWorktree={mockWorktree}
+          worktreeCount={2}
+        />
+      );
+
+      const output = lastFrame();
+      expect(output).toContain('/src/components');
+      expect(output).not.toContain('/Users/dev/project/src/components');
+    });
+
+    it('shows absolute path when cwd is outside worktree', () => {
+      const { lastFrame } = render(
+        <Header
+          cwd="/Users/dev/other-project"
+          filterActive={false}
+          filterQuery=""
+          currentWorktree={mockWorktree}
+          worktreeCount={1}
+        />
+      );
+
+      const output = lastFrame();
+      expect(output).toContain('/Users/dev/other-project');
+    });
+
+    it('shows absolute path for prefix-only match (not descendant)', () => {
+      const { lastFrame } = render(
+        <Header
+          cwd="/Users/dev/project-old"
+          filterActive={false}
+          filterQuery=""
+          currentWorktree={mockWorktree}
+          worktreeCount={1}
+        />
+      );
+
+      const output = lastFrame();
+      // Should show full absolute path, not a mangled relative path
+      expect(output).toContain('/Users/dev/project-old');
+      // Verify it's showing the absolute path, not trying to make it relative
+      expect(output).not.toMatch(/•\s+\/old/); // Would be wrong relative path
+    });
+
+    it('shows root path (/) when at worktree root', () => {
+      const { lastFrame } = render(
+        <Header
+          cwd="/Users/dev/project"
+          filterActive={false}
+          filterQuery=""
+          currentWorktree={mockWorktree}
+          worktreeCount={1}
+        />
+      );
+
+      const output = lastFrame();
+      expect(output).toContain('•');
+      // Should show / for root, not empty string
+      expect(output).toMatch(/•\s+\//); // • followed by /
+    });
+
+    it('renders filter indicator when active', () => {
+      const { lastFrame } = render(
+        <Header
+          cwd="/Users/dev/project"
+          filterActive={true}
+          filterQuery=".ts"
+        />
+      );
+
+      const output = lastFrame();
+      expect(output).toContain('[*]');
+      expect(output).toContain('.ts');
+    });
+
+    it('renders both worktree and filter indicators together', () => {
+      const { lastFrame } = render(
+        <Header
+          cwd="/Users/dev/project"
+          filterActive={true}
+          filterQuery="*.tsx"
+          currentWorktree={mockWorktree}
+          worktreeCount={2}
+        />
+      );
+
+      const output = lastFrame();
+      expect(output).toContain('wt');
+      expect(output).toContain('[main]');
+      expect(output).toContain('(2)');
+      expect(output).toContain('[*]');
+      expect(output).toContain('*.tsx');
+    });
+
+    it('does not show filter indicator when filterActive is false with query', () => {
+      const { lastFrame } = render(
+        <Header
+          cwd="/Users/dev/project"
+          filterActive={false}
+          filterQuery=".ts"
+        />
+      );
+
+      const output = lastFrame();
+      expect(output).not.toContain('[*]');
+      expect(output).not.toContain('.ts');
+    });
+
+    it('shows filter indicator when active with empty query', () => {
+      const { lastFrame } = render(
+        <Header
+          cwd="/Users/dev/project"
+          filterActive={true}
+          filterQuery=""
+        />
+      );
+
+      const output = lastFrame();
+      expect(output).toContain('[*]');
+    });
+  });
+
+  describe('worktree scenarios', () => {
+    it('handles single worktree (count = 1)', () => {
+      const { lastFrame } = render(
+        <Header
+          cwd="/Users/dev/project"
+          filterActive={false}
+          filterQuery=""
+          currentWorktree={mockWorktree}
+          worktreeCount={1}
+        />
+      );
+
+      const output = lastFrame();
+      expect(output).toContain('(1)');
+    });
+
+    it('handles multiple worktrees', () => {
+      const { lastFrame } = render(
+        <Header
+          cwd="/Users/dev/project"
+          filterActive={false}
+          filterQuery=""
+          currentWorktree={mockWorktree}
+          worktreeCount={5}
+        />
+      );
+
+      const output = lastFrame();
+      expect(output).toContain('(5)');
+    });
+
+    it('handles detached HEAD state', () => {
+      const detachedWorktree: Worktree = {
+        id: '/Users/dev/project',
+        path: '/Users/dev/project',
+        name: 'detached',
+        branch: undefined, // No branch in detached state
+        isCurrent: true,
+      };
+
+      const { lastFrame } = render(
+        <Header
+          cwd="/Users/dev/project"
+          filterActive={false}
+          filterQuery=""
+          currentWorktree={detachedWorktree}
+          worktreeCount={1}
+        />
+      );
+
+      const output = lastFrame();
+      expect(output).toContain('[detached]');
+    });
+
+    it('handles feature branch with slashes', () => {
+      const featureWorktree: Worktree = {
+        id: '/Users/dev/project-feature',
+        path: '/Users/dev/project-feature',
+        name: 'feature/auth',
+        branch: 'feature/auth',
+        isCurrent: true,
+      };
+
+      const { lastFrame } = render(
+        <Header
+          cwd="/Users/dev/project-feature"
+          filterActive={false}
+          filterQuery=""
+          currentWorktree={featureWorktree}
+          worktreeCount={2}
+        />
+      );
+
+      const output = lastFrame();
+      expect(output).toContain('[feature/auth]');
+    });
+
+    it('truncates very long branch names', () => {
+      const longBranchWorktree: Worktree = {
+        id: '/Users/dev/project',
+        path: '/Users/dev/project',
+        name: 'feature/this-is-a-very-long-branch-name-that-should-be-truncated',
+        branch: 'feature/this-is-a-very-long-branch-name-that-should-be-truncated',
+        isCurrent: true,
+      };
+
+      const { lastFrame } = render(
+        <Header
+          cwd="/Users/dev/project"
+          filterActive={false}
+          filterQuery=""
+          currentWorktree={longBranchWorktree}
+          worktreeCount={1}
+        />
+      );
+
+      const output = lastFrame();
+      // Should contain exact truncated string (19 chars + ellipsis = 20 total)
+      expect(output).toContain('[feature/this-is-a-v…]');
+      // Full branch name should NOT be present
+      expect(output).not.toContain('feature/this-is-a-very-long-branch-name-that-should-be-truncated');
+    });
+
+    it('shows worktree indicator even without explicit worktreeCount', () => {
+      const { lastFrame } = render(
+        <Header
+          cwd="/Users/dev/project"
+          filterActive={false}
+          filterQuery=""
+          currentWorktree={mockWorktree}
+          // worktreeCount not passed (defaults to 0)
+        />
+      );
+
+      const output = lastFrame();
+      expect(output).toContain('wt');
+      expect(output).toContain('[main]');
+      expect(output).toContain('(0)');
+    });
+
+    it('does not show worktree indicator when currentWorktree is null', () => {
+      const { lastFrame } = render(
+        <Header
+          cwd="/Users/dev/project"
+          filterActive={false}
+          filterQuery=""
+          currentWorktree={null}
+          worktreeCount={3}
+        />
+      );
+
+      const output = lastFrame();
+      expect(output).not.toContain('wt');
+    });
+
+    it('does not show worktree indicator when currentWorktree is undefined', () => {
+      const { lastFrame } = render(
+        <Header
+          cwd="/Users/dev/project"
+          filterActive={false}
+          filterQuery=""
+          // currentWorktree not passed (undefined)
+          worktreeCount={3}
+        />
+      );
+
+      const output = lastFrame();
+      expect(output).not.toContain('wt');
+    });
+
+    it('uses worktree name as fallback when branch is undefined (detached HEAD)', () => {
+      const detachedWithName: Worktree = {
+        id: '/Users/dev/project',
+        path: '/Users/dev/project',
+        name: 'yellowwood-issue-42',
+        branch: undefined,
+        isCurrent: true,
+      };
+
+      const { lastFrame } = render(
+        <Header
+          cwd="/Users/dev/project"
+          filterActive={false}
+          filterQuery=""
+          currentWorktree={detachedWithName}
+          worktreeCount={1}
+        />
+      );
+
+      const output = lastFrame();
+      expect(output).toContain('[yellowwood-issue-42]');
+      expect(output).not.toContain('[detached]');
+    });
+  });
+
+  describe('click handling', () => {
+    it('calls onWorktreeClick when w key pressed', () => {
+      const onWorktreeClick = vi.fn();
+
+      const { stdin } = render(
+        <Header
+          cwd="/Users/dev/project"
+          filterActive={false}
+          filterQuery=""
+          currentWorktree={mockWorktree}
+          worktreeCount={2}
+          onWorktreeClick={onWorktreeClick}
+        />
+      );
+
+      // Simulate 'w' key press
+      stdin.write('w');
+
+      expect(onWorktreeClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onWorktreeClick when w pressed without worktree', () => {
+      const onWorktreeClick = vi.fn();
+
+      const { stdin } = render(
+        <Header
+          cwd="/Users/dev/project"
+          filterActive={false}
+          filterQuery=""
+          currentWorktree={null}
+          worktreeCount={0}
+          onWorktreeClick={onWorktreeClick}
+        />
+      );
+
+      stdin.write('w');
+
+      expect(onWorktreeClick).not.toHaveBeenCalled();
+    });
+
+    it('does not crash when onWorktreeClick is undefined', () => {
+      const { stdin } = render(
+        <Header
+          cwd="/Users/dev/project"
+          filterActive={false}
+          filterQuery=""
+          currentWorktree={mockWorktree}
+          worktreeCount={2}
+        />
+      );
+
+      // Should not crash
+      expect(() => stdin.write('w')).not.toThrow();
+    });
+
+    it('does not call onWorktreeClick when other keys are pressed', () => {
+      const onWorktreeClick = vi.fn();
+
+      const { stdin } = render(
+        <Header
+          cwd="/Users/dev/project"
+          filterActive={false}
+          filterQuery=""
+          currentWorktree={mockWorktree}
+          worktreeCount={2}
+          onWorktreeClick={onWorktreeClick}
+        />
+      );
+
+      // Try various other keys
+      stdin.write('a');
+      stdin.write('W'); // uppercase
+      stdin.write('q');
+      stdin.write('x');
+
+      expect(onWorktreeClick).not.toHaveBeenCalled();
+    });
+
+    it('does not call onWorktreeClick when w pressed with filter active', () => {
+      const onWorktreeClick = vi.fn();
+
+      const { stdin } = render(
+        <Header
+          cwd="/Users/dev/project"
+          filterActive={true}
+          filterQuery="test"
+          currentWorktree={mockWorktree}
+          worktreeCount={2}
+          onWorktreeClick={onWorktreeClick}
+        />
+      );
+
+      stdin.write('w');
+
+      // Should not trigger because filter is active
+      expect(onWorktreeClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('visual styling', () => {
+    it('uses bullet separator (•) not dash (-)', () => {
+      const { lastFrame } = render(
+        <Header
+          cwd="/Users/dev/project"
+          filterActive={false}
+          filterQuery=""
+          currentWorktree={mockWorktree}
+          worktreeCount={2}
+        />
+      );
+
+      const output = lastFrame();
+      expect(output).toContain('•');
+      // Should not have the old " - " separator format
+      expect(output).not.toMatch(/Yellowwood\s+-\s+/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Enhanced the Header component to display active worktree information with clickable navigation. The Header now shows which worktree is active, the total count, and provides a keyboard shortcut for quick worktree switching.

Closes #18

## Changes Made

- Add worktree indicator showing branch name and count (wt [branch] (count))
- Implement keyboard shortcut 'w' for worktree panel navigation
- Add filter-aware keyboard handling to prevent input interception
- Use path.relative() for proper relative path calculation
- Handle detached HEAD with intelligent fallback (branch → name → 'detached')
- Truncate long branch names (max 20 chars) with ellipsis
- Style clickable elements with bold and underline
- Change separator from " - " to " • " for better visual hierarchy
- Add 25 comprehensive test cases covering all edge cases

## Implementation Notes

### Context & rationale

* Enhanced Header component to display active worktree information (name and count)
* Transforms Header from simple directory display into worktree-aware navigation control
* Provides visual context for developers working across multiple branches simultaneously
* Clickable interaction with keyboard shortcut 'w' enables quick access to worktree switching

### Implementation details

* Added three optional props: `currentWorktree`, `worktreeCount`, `onWorktreeClick`
* Implemented worktree indicator with format: `wt [branch] (count)`
* Added keyboard handler using Ink's `useInput` hook for 'w' key shortcut with filter-awareness
* Changed separator from " - " to " • " for better visual hierarchy
* Uses `path.relative()` for proper relative path calculation (handles edge cases)
* Truncates long branch names (max 20 chars) with ellipsis
* Handles detached HEAD with intelligent fallback: branch → name → 'detached'
* Clickable elements styled with bold + underline when callback provided
* Shows indicator based on `currentWorktree` presence (not count)
* Keyboard shortcut respects filter state to avoid intercepting filter input
* Proper handling of paths outside worktree and prefix-only matches
* Comprehensive test coverage: 25 test cases covering all edge cases

## Breaking Changes & Migration Hints

### Breaking changes

* None - all new props are optional with backward compatibility maintained

### Migration hints

* Existing usage without worktree props continues to work unchanged
* To enable worktree display, pass `currentWorktree`, `worktreeCount`, and `onWorktreeClick` props
* Format: `Yellowwood • wt [branch] (count) • /path`

## Follow-up Tasks

* App.tsx integration will need to pass worktree data from useFileTree hook
* WorktreePanel component (issue #21) will be triggered by onWorktreeClick callback
* Consider terminal width detection for dynamic truncation limits (future enhancement)