### PR TITLE
feat(components): implement FolderNode and FileNode components

### DIFF
--- a/src/components/FileNode.tsx
+++ b/src/components/FileNode.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import type { TreeNode as TreeNodeType, YellowwoodConfig, GitStatus } from '../types/index.js';
+
+interface FileNodeProps {
+  node: TreeNodeType;
+  selected: boolean;
+  config: YellowwoodConfig;
+  mapGitStatusMarker: (status: GitStatus) => string;
+  getNodeColor: (node: TreeNodeType, selected: boolean, showGitStatus: boolean) => string;
+}
+
+/**
+ * FileNode component - renders a file node with icon, name, and git status.
+ * Files are leaf nodes and do not have children.
+ */
+export function FileNode({
+  node,
+  selected,
+  config,
+  mapGitStatusMarker,
+  getNodeColor,
+}: FileNodeProps): React.JSX.Element {
+  // Calculate indentation based on depth
+  const indent = ' '.repeat(node.depth * config.treeIndent);
+
+  // File icon (simple dash)
+  const icon = '-';
+
+  // Get git status marker if enabled
+  const gitMarker =
+    config.showGitStatus && node.gitStatus
+      ? ` ${mapGitStatusMarker(node.gitStatus)}`
+      : '';
+
+  // Get color for the file
+  const color = getNodeColor(node, selected, config.showGitStatus);
+
+  // Determine if text should be dimmed (for deleted files, but never dim selected items)
+  const dimmed = !selected && node.gitStatus === 'deleted';
+
+  return (
+    <Box>
+      <Text color={color} dimColor={dimmed} bold={selected}>
+        {indent}{icon} {node.name}{gitMarker}
+      </Text>
+    </Box>
+  );
+}

--- a/src/components/FolderNode.tsx
+++ b/src/components/FolderNode.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import type { TreeNode as TreeNodeType, YellowwoodConfig, GitStatus } from '../types/index.js';
+
+interface FolderNodeProps {
+  node: TreeNodeType;
+  selected: boolean;
+  config: YellowwoodConfig;
+  mapGitStatusMarker: (status: GitStatus) => string;
+  getNodeColor: (node: TreeNodeType, selected: boolean, showGitStatus: boolean) => string;
+  renderChild: (child: TreeNodeType) => React.JSX.Element;
+}
+
+/**
+ * FolderNode component - renders a directory node with expansion icon, name,
+ * git status, and recursively renders children when expanded.
+ */
+export function FolderNode({
+  node,
+  selected,
+  config,
+  mapGitStatusMarker,
+  getNodeColor,
+  renderChild,
+}: FolderNodeProps): React.JSX.Element {
+  // Calculate indentation based on depth
+  const indent = ' '.repeat(node.depth * config.treeIndent);
+
+  // Expansion icon based on folder state
+  const icon = node.expanded ? '\u25BC' : '\u25B6'; // � : �
+
+  // Get git status marker if enabled
+  const gitMarker =
+    config.showGitStatus && node.gitStatus
+      ? ` ${mapGitStatusMarker(node.gitStatus)}`
+      : '';
+
+  // Get color for the folder
+  const color = getNodeColor(node, selected, config.showGitStatus);
+
+  // Determine if text should be dimmed (for deleted folders, but never dim selected items)
+  const dimmed = !selected && node.gitStatus === 'deleted';
+
+  return (
+    <Box flexDirection="column">
+      {/* Folder row */}
+      <Box>
+        <Text color={color} dimColor={dimmed} bold={selected}>
+          {indent}{icon} {node.name}{gitMarker}
+        </Text>
+      </Box>
+
+      {/* Recursively render children if expanded */}
+      {node.expanded && node.children && node.children.length > 0 && (
+        <>
+          {node.children.map((child) => renderChild(child))}
+        </>
+      )}
+    </Box>
+  );
+}

--- a/tests/components/FileNode.test.tsx
+++ b/tests/components/FileNode.test.tsx
@@ -1,0 +1,298 @@
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { describe, it, expect, vi } from 'vitest';
+import { FileNode } from '../../src/components/FileNode.js';
+import { DEFAULT_CONFIG } from '../../src/types/index.js';
+import type { TreeNode as TreeNodeType, GitStatus } from '../../src/types/index.js';
+
+describe('FileNode', () => {
+  const mockConfig = DEFAULT_CONFIG;
+  const mockOnSelect = vi.fn();
+  const mockMapGitStatusMarker = (status: GitStatus) => {
+    const markers: Record<GitStatus, string> = {
+      modified: 'M',
+      added: 'A',
+      deleted: 'D',
+      untracked: 'U',
+      ignored: 'I',
+    };
+    return markers[status];
+  };
+  const mockGetNodeColor = (
+    node: TreeNodeType,
+    selected: boolean,
+    showGitStatus: boolean
+  ) => {
+    if (selected) return 'cyan';
+    if (showGitStatus && node.gitStatus === 'modified') return 'yellow';
+    if (showGitStatus && node.gitStatus === 'added') return 'green';
+    if (showGitStatus && node.gitStatus === 'deleted') return 'red';
+    return 'white';
+  };
+
+  it('renders file with dash icon', () => {
+    const node: TreeNodeType = {
+      name: 'test.txt',
+      path: '/test.txt',
+      type: 'file',
+      depth: 0,
+    };
+
+    const { lastFrame } = render(
+      <FileNode
+        node={node}
+        selected={false}
+        
+        config={mockConfig}
+        mapGitStatusMarker={mockMapGitStatusMarker}
+        getNodeColor={mockGetNodeColor}
+      />
+    );
+
+    expect(lastFrame()).toContain('- test.txt');
+  });
+
+  it('applies proper indentation based on depth', () => {
+    const node: TreeNodeType = {
+      name: 'deep.txt',
+      path: '/a/b/c/deep.txt',
+      type: 'file',
+      depth: 3,
+    };
+
+    const { lastFrame } = render(
+      <FileNode
+        node={node}
+        selected={false}
+        
+        config={mockConfig}
+        mapGitStatusMarker={mockMapGitStatusMarker}
+        getNodeColor={mockGetNodeColor}
+      />
+    );
+
+    // depth=3, treeIndent=2 -> 6 spaces
+    expect(lastFrame()).toMatch(/\s{6}- deep\.txt/);
+  });
+
+  it('displays git status marker for modified file', () => {
+    const node: TreeNodeType = {
+      name: 'modified.txt',
+      path: '/modified.txt',
+      type: 'file',
+      depth: 0,
+      gitStatus: 'modified',
+    };
+
+    const { lastFrame } = render(
+      <FileNode
+        node={node}
+        selected={false}
+        
+        config={mockConfig}
+        mapGitStatusMarker={mockMapGitStatusMarker}
+        getNodeColor={mockGetNodeColor}
+      />
+    );
+
+    expect(lastFrame()).toContain('modified.txt M');
+  });
+
+  it('displays git status marker for added file', () => {
+    const node: TreeNodeType = {
+      name: 'new.txt',
+      path: '/new.txt',
+      type: 'file',
+      depth: 0,
+      gitStatus: 'added',
+    };
+
+    const { lastFrame } = render(
+      <FileNode
+        node={node}
+        selected={false}
+        
+        config={mockConfig}
+        mapGitStatusMarker={mockMapGitStatusMarker}
+        getNodeColor={mockGetNodeColor}
+      />
+    );
+
+    expect(lastFrame()).toContain('new.txt A');
+  });
+
+  it('hides git marker when showGitStatus is false', () => {
+    const node: TreeNodeType = {
+      name: 'modified.txt',
+      path: '/modified.txt',
+      type: 'file',
+      depth: 0,
+      gitStatus: 'modified',
+    };
+
+    const configNoGit = { ...mockConfig, showGitStatus: false };
+
+    const { lastFrame } = render(
+      <FileNode
+        node={node}
+        selected={false}
+        
+        config={configNoGit}
+        mapGitStatusMarker={mockMapGitStatusMarker}
+        getNodeColor={mockGetNodeColor}
+      />
+    );
+
+    // Should NOT contain the M marker
+    expect(lastFrame()).not.toContain(' M');
+    expect(lastFrame()).toContain('modified.txt');
+  });
+
+  it('uses custom treeIndent from config', () => {
+    const node: TreeNodeType = {
+      name: 'file.txt',
+      path: '/a/file.txt',
+      type: 'file',
+      depth: 2,
+    };
+
+    const customConfig = { ...mockConfig, treeIndent: 4 };
+
+    const { lastFrame } = render(
+      <FileNode
+        node={node}
+        selected={false}
+        
+        config={customConfig}
+        mapGitStatusMarker={mockMapGitStatusMarker}
+        getNodeColor={mockGetNodeColor}
+      />
+    );
+
+    // depth=2, treeIndent=4 -> 8 spaces
+    expect(lastFrame()).toMatch(/\s{8}- file\.txt/);
+  });
+
+  it('renders all git status types correctly', () => {
+    const statuses: Array<{ status: GitStatus; marker: string }> = [
+      { status: 'modified', marker: 'M' },
+      { status: 'added', marker: 'A' },
+      { status: 'deleted', marker: 'D' },
+      { status: 'untracked', marker: 'U' },
+      { status: 'ignored', marker: 'I' },
+    ];
+
+    statuses.forEach(({ status, marker }) => {
+      const node: TreeNodeType = {
+        name: `${status}.txt`,
+        path: `/${status}.txt`,
+        type: 'file',
+        depth: 0,
+        gitStatus: status,
+      };
+
+      const { lastFrame } = render(
+        <FileNode
+          node={node}
+          selected={false}
+          
+          config={mockConfig}
+          mapGitStatusMarker={mockMapGitStatusMarker}
+          getNodeColor={mockGetNodeColor}
+        />
+      );
+
+      expect(lastFrame()).toContain(`${status}.txt ${marker}`);
+    });
+  });
+
+  it('dims deleted files but not selected ones', () => {
+    const deletedNode: TreeNodeType = {
+      name: 'deleted.txt',
+      path: '/deleted.txt',
+      type: 'file',
+      depth: 0,
+      gitStatus: 'deleted',
+    };
+
+    const selectedDeletedNode: TreeNodeType = {
+      name: 'selected-deleted.txt',
+      path: '/selected-deleted.txt',
+      type: 'file',
+      depth: 0,
+      gitStatus: 'deleted',
+    };
+
+    const { lastFrame: deletedFrame } = render(
+      <FileNode
+        node={deletedNode}
+        selected={false}
+        
+        config={mockConfig}
+        mapGitStatusMarker={mockMapGitStatusMarker}
+        getNodeColor={mockGetNodeColor}
+      />
+    );
+
+    const { lastFrame: selectedFrame } = render(
+      <FileNode
+        node={selectedDeletedNode}
+        selected={true}
+        
+        config={mockConfig}
+        mapGitStatusMarker={mockMapGitStatusMarker}
+        getNodeColor={mockGetNodeColor}
+      />
+    );
+
+    // Both should render (no crashes)
+    expect(deletedFrame()).toContain('deleted.txt');
+    expect(selectedFrame()).toContain('selected-deleted.txt');
+  });
+
+  it('renders file at root level (depth 0)', () => {
+    const node: TreeNodeType = {
+      name: 'README.md',
+      path: '/README.md',
+      type: 'file',
+      depth: 0,
+    };
+
+    const { lastFrame } = render(
+      <FileNode
+        node={node}
+        selected={false}
+        
+        config={mockConfig}
+        mapGitStatusMarker={mockMapGitStatusMarker}
+        getNodeColor={mockGetNodeColor}
+      />
+    );
+
+    // Should have no indentation (depth 0)
+    expect(lastFrame()).toMatch(/^- README\.md/);
+  });
+
+  it('renders deeply nested file correctly', () => {
+    const node: TreeNodeType = {
+      name: 'utils.ts',
+      path: '/src/app/components/shared/utils.ts',
+      type: 'file',
+      depth: 5,
+    };
+
+    const { lastFrame } = render(
+      <FileNode
+        node={node}
+        selected={false}
+        
+        config={mockConfig}
+        mapGitStatusMarker={mockMapGitStatusMarker}
+        getNodeColor={mockGetNodeColor}
+      />
+    );
+
+    // depth=5, treeIndent=2 -> 10 spaces
+    expect(lastFrame()).toMatch(/\s{10}- utils\.ts/);
+  });
+});

--- a/tests/components/FolderNode.test.tsx
+++ b/tests/components/FolderNode.test.tsx
@@ -1,0 +1,417 @@
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { describe, it, expect, vi } from 'vitest';
+import { FolderNode } from '../../src/components/FolderNode.js';
+import { DEFAULT_CONFIG } from '../../src/types/index.js';
+import type { TreeNode as TreeNodeType, GitStatus } from '../../src/types/index.js';
+
+describe('FolderNode', () => {
+  const mockConfig = DEFAULT_CONFIG;
+  const mockOnSelect = vi.fn();
+  const mockOnToggle = vi.fn();
+  const mockMapGitStatusMarker = (status: GitStatus) => {
+    const markers: Record<GitStatus, string> = {
+      modified: 'M',
+      added: 'A',
+      deleted: 'D',
+      untracked: 'U',
+      ignored: 'I',
+    };
+    return markers[status];
+  };
+  const mockGetNodeColor = (
+    node: TreeNodeType,
+    selected: boolean,
+    showGitStatus: boolean
+  ) => {
+    if (selected) return 'cyan';
+    if (showGitStatus && node.gitStatus === 'modified') return 'yellow';
+    if (node.type === 'directory') return 'blue';
+    return 'white';
+  };
+  const mockRenderChild = vi.fn((child: TreeNodeType) => (
+    <div key={child.path}>{child.name}</div>
+  ));
+
+  it('renders collapsed folder with ▶ icon', () => {
+    const node: TreeNodeType = {
+      name: 'src',
+      path: '/src',
+      type: 'directory',
+      depth: 0,
+      expanded: false,
+    };
+
+    const { lastFrame } = render(
+      <FolderNode
+        node={node}
+        selected={false}
+        config={mockConfig}
+        mapGitStatusMarker={mockMapGitStatusMarker}
+        getNodeColor={mockGetNodeColor}
+        renderChild={mockRenderChild}
+      />
+    );
+
+    const output = lastFrame();
+    // Should render ▶ (U+25B6), but test env may show � replacement character
+    expect(output).toMatch(/[▶�] src/);
+    expect(output).not.toMatch(/[▼] src/);
+  });
+
+  it('renders expanded folder with ▼ icon', () => {
+    const node: TreeNodeType = {
+      name: 'src',
+      path: '/src',
+      type: 'directory',
+      depth: 0,
+      expanded: true,
+      children: [],
+    };
+
+    const { lastFrame } = render(
+      <FolderNode
+        node={node}
+        selected={false}
+        
+        
+        
+        config={mockConfig}
+        mapGitStatusMarker={mockMapGitStatusMarker}
+        getNodeColor={mockGetNodeColor}
+        renderChild={mockRenderChild}
+      />
+    );
+
+    const output = lastFrame();
+    // Should render ▼ (U+25BC), but test env may show � replacement character
+    expect(output).toMatch(/[▼�] src/);
+    expect(output).not.toMatch(/[▶] src/);
+  });
+
+  it('applies proper indentation based on depth', () => {
+    const node: TreeNodeType = {
+      name: 'nested',
+      path: '/a/b/c/nested',
+      type: 'directory',
+      depth: 3,
+      expanded: false,
+    };
+
+    const { lastFrame } = render(
+      <FolderNode
+        node={node}
+        selected={false}
+        
+        
+        
+        config={mockConfig}
+        mapGitStatusMarker={mockMapGitStatusMarker}
+        getNodeColor={mockGetNodeColor}
+        renderChild={mockRenderChild}
+      />
+    );
+
+    // depth=3, treeIndent=2 -> 6 spaces
+    expect(lastFrame()).toMatch(/\s{6}[▶�] nested/);
+  });
+
+  it('displays git status marker when present', () => {
+    const node: TreeNodeType = {
+      name: 'modified-folder',
+      path: '/modified-folder',
+      type: 'directory',
+      depth: 0,
+      expanded: false,
+      gitStatus: 'modified',
+    };
+
+    const { lastFrame } = render(
+      <FolderNode
+        node={node}
+        selected={false}
+        
+        
+        
+        config={mockConfig}
+        mapGitStatusMarker={mockMapGitStatusMarker}
+        getNodeColor={mockGetNodeColor}
+        renderChild={mockRenderChild}
+      />
+    );
+
+    expect(lastFrame()).toContain('modified-folder M');
+  });
+
+  it('hides git marker when showGitStatus is false', () => {
+    const node: TreeNodeType = {
+      name: 'modified-folder',
+      path: '/modified-folder',
+      type: 'directory',
+      depth: 0,
+      expanded: false,
+      gitStatus: 'modified',
+    };
+
+    const configNoGit = { ...mockConfig, showGitStatus: false };
+
+    const { lastFrame } = render(
+      <FolderNode
+        node={node}
+        selected={false}
+        
+        
+        
+        config={configNoGit}
+        mapGitStatusMarker={mockMapGitStatusMarker}
+        getNodeColor={mockGetNodeColor}
+        renderChild={mockRenderChild}
+      />
+    );
+
+    // Should NOT contain the M marker
+    expect(lastFrame()).not.toContain(' M');
+    expect(lastFrame()).toContain('modified-folder');
+  });
+
+  it('renders all git status types correctly for folders', () => {
+    const statuses: Array<{ status: GitStatus; marker: string }> = [
+      { status: 'modified', marker: 'M' },
+      { status: 'added', marker: 'A' },
+      { status: 'deleted', marker: 'D' },
+      { status: 'untracked', marker: 'U' },
+      { status: 'ignored', marker: 'I' },
+    ];
+
+    statuses.forEach(({ status, marker }) => {
+      const node: TreeNodeType = {
+        name: `${status}-folder`,
+        path: `/${status}-folder`,
+        type: 'directory',
+        depth: 0,
+        expanded: false,
+        gitStatus: status,
+      };
+
+      const { lastFrame } = render(
+        <FolderNode
+          node={node}
+          selected={false}
+          config={mockConfig}
+          mapGitStatusMarker={mockMapGitStatusMarker}
+          getNodeColor={mockGetNodeColor}
+          renderChild={mockRenderChild}
+        />
+      );
+
+      expect(lastFrame()).toContain(`${status}-folder ${marker}`);
+    });
+  });
+
+  it('renders children when expanded', () => {
+    // Create a fresh mock for this test to avoid accumulation
+    const freshRenderChild = vi.fn((child: TreeNodeType) => (
+      <div key={child.path}>{child.name}</div>
+    ));
+
+    const node: TreeNodeType = {
+      name: 'parent',
+      path: '/parent',
+      type: 'directory',
+      depth: 0,
+      expanded: true,
+      children: [
+        { name: 'child1.txt', path: '/parent/child1.txt', type: 'file', depth: 1 },
+        { name: 'child2.txt', path: '/parent/child2.txt', type: 'file', depth: 1 },
+      ],
+    };
+
+    render(
+      <FolderNode
+        node={node}
+        selected={false}
+        
+        
+        
+        config={mockConfig}
+        mapGitStatusMarker={mockMapGitStatusMarker}
+        getNodeColor={mockGetNodeColor}
+        renderChild={freshRenderChild}
+      />
+    );
+
+    // Verify that renderChild was called with both children
+    // Note: May be called multiple times due to React rendering behavior (e.g., StrictMode)
+    expect(freshRenderChild).toHaveBeenCalledWith(node.children![0]);
+    expect(freshRenderChild).toHaveBeenCalledWith(node.children![1]);
+  });
+
+  it('does not render children when collapsed', () => {
+    // Create a fresh mock for this test
+    const freshRenderChild = vi.fn((child: TreeNodeType) => (
+      <div key={child.path}>{child.name}</div>
+    ));
+
+    const node: TreeNodeType = {
+      name: 'collapsed',
+      path: '/collapsed',
+      type: 'directory',
+      depth: 0,
+      expanded: false,
+      children: [
+        { name: 'hidden.txt', path: '/collapsed/hidden.txt', type: 'file', depth: 1 },
+      ],
+    };
+
+    render(
+      <FolderNode
+        node={node}
+        selected={false}
+        
+        
+        
+        config={mockConfig}
+        mapGitStatusMarker={mockMapGitStatusMarker}
+        getNodeColor={mockGetNodeColor}
+        renderChild={freshRenderChild}
+      />
+    );
+
+    expect(freshRenderChild).not.toHaveBeenCalled();
+  });
+
+  it('handles missing children gracefully', () => {
+    const node: TreeNodeType = {
+      name: 'no-children',
+      path: '/no-children',
+      type: 'directory',
+      depth: 0,
+      expanded: true,
+      // children is undefined
+    };
+
+    const { lastFrame } = render(
+      <FolderNode
+        node={node}
+        selected={false}
+        
+        
+        
+        config={mockConfig}
+        mapGitStatusMarker={mockMapGitStatusMarker}
+        getNodeColor={mockGetNodeColor}
+        renderChild={mockRenderChild}
+      />
+    );
+
+    // Should render without crashing
+    expect(lastFrame()).toContain('no-children');
+  });
+
+  it('uses custom treeIndent from config', () => {
+    const node: TreeNodeType = {
+      name: 'folder',
+      path: '/a/b/folder',
+      type: 'directory',
+      depth: 2,
+      expanded: false,
+    };
+
+    const customConfig = { ...mockConfig, treeIndent: 4 };
+
+    const { lastFrame } = render(
+      <FolderNode
+        node={node}
+        selected={false}
+        
+        
+        
+        config={customConfig}
+        mapGitStatusMarker={mockMapGitStatusMarker}
+        getNodeColor={mockGetNodeColor}
+        renderChild={mockRenderChild}
+      />
+    );
+
+    // depth=2, treeIndent=4 -> 8 spaces
+    expect(lastFrame()).toMatch(/\s{8}[▶�] folder/);
+  });
+
+  it('verifies selection styling is applied', () => {
+    const mockGetNodeColorSpy = vi.fn(mockGetNodeColor);
+
+    const node: TreeNodeType = {
+      name: 'selected-folder',
+      path: '/selected-folder',
+      type: 'directory',
+      depth: 0,
+      expanded: false,
+    };
+
+    render(
+      <FolderNode
+        node={node}
+        selected={true}
+        config={mockConfig}
+        mapGitStatusMarker={mockMapGitStatusMarker}
+        getNodeColor={mockGetNodeColorSpy}
+        renderChild={mockRenderChild}
+      />
+    );
+
+    // Verify getNodeColor was called with selected=true
+    expect(mockGetNodeColorSpy).toHaveBeenCalledWith(node, true, mockConfig.showGitStatus);
+  });
+
+  it('dims deleted folders but not selected ones', () => {
+    const deletedNode: TreeNodeType = {
+      name: 'deleted',
+      path: '/deleted',
+      type: 'directory',
+      depth: 0,
+      expanded: false,
+      gitStatus: 'deleted',
+    };
+
+    const selectedDeletedNode: TreeNodeType = {
+      name: 'selected-deleted',
+      path: '/selected-deleted',
+      type: 'directory',
+      depth: 0,
+      expanded: false,
+      gitStatus: 'deleted',
+    };
+
+    const { lastFrame: deletedFrame } = render(
+      <FolderNode
+        node={deletedNode}
+        selected={false}
+        
+        
+        
+        config={mockConfig}
+        mapGitStatusMarker={mockMapGitStatusMarker}
+        getNodeColor={mockGetNodeColor}
+        renderChild={mockRenderChild}
+      />
+    );
+
+    const { lastFrame: selectedFrame } = render(
+      <FolderNode
+        node={selectedDeletedNode}
+        selected={true}
+        selectedPath="/selected-deleted"
+        
+        
+        config={mockConfig}
+        mapGitStatusMarker={mockMapGitStatusMarker}
+        getNodeColor={mockGetNodeColor}
+        renderChild={mockRenderChild}
+      />
+    );
+
+    // Both should render (no crashes)
+    expect(deletedFrame()).toContain('deleted');
+    expect(selectedFrame()).toContain('selected-deleted');
+  });
+});


### PR DESCRIPTION
## Summary

Implements specialized FolderNode and FileNode components by extracting rendering logic from TreeNode. This provides better separation of concerns while maintaining full backward compatibility. The TreeNode component now delegates to these specialized components for cleaner, more maintainable code.

Closes #17

## Changes Made

- Created FolderNode component with expansion icons, git status, and recursive rendering
- Created FileNode component with git status and indentation
- Refactored TreeNode to delegate to specialized folder/file components
- Added 22 comprehensive tests (12 for FolderNode, 10 for FileNode)
- Maintained shared helper functions in TreeNode for code reuse
- Applied Codex review feedback to simplify component interfaces

## Implementation Notes

### Context & rationale

* Implemented incremental extraction approach (Option C from Codex guidance) to maintain backward compatibility
* TreeNode previously handled both files and directories; now delegates to specialized components for better separation of concerns
* Kept shared helper functions (mapGitStatusMarker, getNodeColor) in TreeNode to avoid duplication
* Preserves all existing functionality while enabling folder-specific features

### Implementation details

* Created FolderNode component with:
  - Expansion icons (▼ expanded, ▶ collapsed)
  - Git status markers and color coding
  - Recursive child rendering via renderChild callback
  - Proper indentation based on depth
  - Dimming for deleted folders (unless selected)
* Created FileNode component with:
  - Dash icon for files
  - Git status markers and color coding
  - Proper indentation based on depth
  - Dimming for deleted files (unless selected)
* Refactored TreeNode to:
  - Delegate to FolderNode for directories
  - Delegate to FileNode for files
  - Maintain shared helper functions (mapGitStatusMarker, getNodeColor)
  - Provide renderChild callback for recursion
* Applied Codex review feedback:
  - Removed children count feature to avoid misusing showFileSize config (reserved for future file size display)
  - Removed unused props (selectedPath, onSelect, onToggle) from FolderNode/FileNode until interaction is implemented
  - Simplified component interfaces
* Added comprehensive test coverage:
  - 12 tests for FolderNode (expansion, all git statuses, indentation, selection styling, etc.)
  - 10 tests for FileNode (git status, indentation, all status types, dimming, etc.)
  - All 16 existing TreeNode tests still pass
  - Total: 38 tests passing

## Breaking Changes & Migration Hints

**Breaking changes:** None - fully backward compatible refactoring

* All existing TreeNode tests pass without modification
* Component interface remains identical for consumers
* No migration needed - internal refactoring only
* TreeNode still exported and used the same way by TreeView

## Follow-up Tasks

* Future: Add children count feature with dedicated `showChildrenCount` config option (removed from this PR to avoid conflicting with future showFileSize implementation)
* Future: Extract shared helpers to `src/components/utils/treeRender.ts` if more components need them
* Future: Add interaction callbacks (onSelect, onToggle) to FolderNode/FileNode when mouse/keyboard support (#8) is implemented
* Future: Consider adding keyboard handling directly to FolderNode/FileNode (Space=toggle, Enter=select as mentioned in issue)