### PR TITLE
Implement command parser and execution system

### DIFF
--- a/src/utils/commandParser.ts
+++ b/src/utils/commandParser.ts
@@ -1,0 +1,383 @@
+import type { YellowwoodState, YellowwoodConfig, Notification } from '../types/index.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface Command {
+  name: string;
+  aliases?: string[];
+  description: string;
+  usage?: string;
+  execute: CommandExecutor;
+}
+
+export type CommandExecutor = (
+  args: string[],
+  context: CommandContext
+) => Promise<CommandResult>;
+
+export interface CommandContext {
+  state: YellowwoodState;
+  setState: (updates: Partial<YellowwoodState>) => void;
+  config: YellowwoodConfig;
+  notify: (notification: Notification) => void;
+}
+
+export interface CommandResult {
+  success: boolean;
+  message?: string;
+  error?: string;
+}
+
+export interface ParsedCommand {
+  command: string;
+  args: string[];
+  rawInput: string;
+}
+
+// ============================================================================
+// Command Parsing
+// ============================================================================
+
+/**
+ * Parse command input into structured format.
+ *
+ * Free text without "/" prefix is treated as "/filter" command.
+ *
+ * Examples:
+ *   "/filter .ts" → { command: '/filter', args: ['.ts'], rawInput: ... }
+ *   "component" → { command: '/filter', args: ['component'], rawInput: ... }
+ *   "/git modified" → { command: '/git', args: ['modified'], rawInput: ... }
+ */
+export function parseCommand(input: string): ParsedCommand {
+  const trimmed = input.trim();
+
+  if (!trimmed) {
+    return { command: '', args: [], rawInput: input };
+  }
+
+  // Check if input starts with /
+  const isCommand = trimmed.startsWith('/');
+
+  // Split by whitespace
+  const parts = trimmed.split(/\s+/);
+
+  if (isCommand) {
+    // Explicit command: /filter .ts
+    return {
+      command: parts[0].toLowerCase(),
+      args: parts.slice(1),
+      rawInput: input,
+    };
+  } else {
+    // Free text: treat entire input as filter argument
+    return {
+      command: '/filter',
+      args: [trimmed],
+      rawInput: input,
+    };
+  }
+}
+
+// ============================================================================
+// Command Registry
+// ============================================================================
+
+/**
+ * Find command in registry by name or alias.
+ * Case-insensitive matching.
+ */
+export function findCommand(name: string, registry: Command[]): Command | null {
+  const normalized = name.toLowerCase();
+
+  return registry.find(cmd => {
+    // Check primary name
+    if (cmd.name.toLowerCase() === normalized) {
+      return true;
+    }
+
+    // Check aliases
+    if (cmd.aliases) {
+      return cmd.aliases.some(alias => alias.toLowerCase() === normalized);
+    }
+
+    return false;
+  }) || null;
+}
+
+/**
+ * Register a new command in the registry.
+ * Validates command structure and checks for duplicates.
+ */
+export function registerCommand(registry: Command[], command: Command): void {
+  // Validate command structure
+  validateCommand(command);
+
+  // Check for duplicate names (only primary names, not aliases)
+  const normalized = command.name.toLowerCase();
+  const existingIndex = registry.findIndex(c => c.name.toLowerCase() === normalized);
+  if (existingIndex >= 0) {
+    console.warn(`Warning: Command ${command.name} already registered (overwriting)`);
+    registry.splice(existingIndex, 1);
+  }
+
+  // Check for alias conflicts
+  if (command.aliases) {
+    for (const alias of command.aliases) {
+      if (findCommand(alias, registry)) {
+        throw new Error(`Alias ${alias} conflicts with existing command`);
+      }
+    }
+  }
+
+  registry.push(command);
+}
+
+/**
+ * Validate command structure.
+ * Throws if command is invalid.
+ */
+function validateCommand(command: Command): void {
+  if (!command.name) {
+    throw new Error('Command must have a name');
+  }
+
+  if (!command.name.startsWith('/')) {
+    throw new Error(`Command name must start with /: ${command.name}`);
+  }
+
+  if (!command.description) {
+    throw new Error(`Command ${command.name} must have a description`);
+  }
+
+  if (typeof command.execute !== 'function') {
+    throw new Error(`Command ${command.name} must have an execute function`);
+  }
+}
+
+/**
+ * Create default command registry with built-in commands.
+ *
+ * Note: Command implementations are stubs that will be filled in by other issues:
+ * - /filter → Issue #25
+ * - /git → Issue #26
+ * - /changed → Issue #26
+ * - /wt → Issue #29
+ * - /open → Implemented here (simple)
+ */
+export function createCommandRegistry(): Command[] {
+  const registry: Command[] = [];
+
+  // /filter command
+  registerCommand(registry, {
+    name: '/filter',
+    aliases: ['/f'],
+    description: 'Filter files by name pattern',
+    usage: '/filter <pattern> | /filter clear',
+    execute: async (args, context) => {
+      // Stub - implementation in issue #25
+      if (args.length === 0) {
+        return { success: false, error: 'Usage: /filter <pattern> or /filter clear' };
+      }
+
+      if (args[0] === 'clear') {
+        context.setState({
+          filterActive: false,
+          filterQuery: '',
+          filteredPaths: [],
+        });
+        context.notify({ type: 'info', message: 'Filter cleared' });
+        return { success: true, message: 'Filter cleared' };
+      }
+
+      // Actual filter logic will be in #25
+      context.setState({
+        filterActive: true,
+        filterQuery: args.join(' '),
+      });
+      context.notify({ type: 'info', message: `Filter: ${args.join(' ')}` });
+      return { success: true, message: `Filtering by: ${args.join(' ')}` };
+    },
+  });
+
+  // /git command
+  registerCommand(registry, {
+    name: '/git',
+    aliases: ['/g'],
+    description: 'Filter by git status',
+    usage: '/git <modified|added|deleted|untracked>',
+    execute: async (args, context) => {
+      // Stub - implementation in issue #26
+      const validStatuses = ['modified', 'added', 'deleted', 'untracked'];
+
+      if (args.length === 0 || !validStatuses.includes(args[0])) {
+        return {
+          success: false,
+          error: `Usage: /git ${validStatuses.join('|')}`,
+        };
+      }
+
+      context.setState({
+        filterActive: true,
+        filterQuery: `git:${args[0]}`,
+      });
+      context.notify({ type: 'info', message: `Git filter: ${args[0]}` });
+      return { success: true, message: `Filtering by git status: ${args[0]}` };
+    },
+  });
+
+  // /changed command
+  registerCommand(registry, {
+    name: '/changed',
+    aliases: ['/c'],
+    description: 'Show all files with any git status',
+    usage: '/changed',
+    execute: async (args, context) => {
+      // Stub - implementation in issue #26
+      context.setState({
+        filterActive: true,
+        filterQuery: 'git:any',
+      });
+      context.notify({ type: 'info', message: 'Showing all changed files' });
+      return { success: true, message: 'Showing all changed files' };
+    },
+  });
+
+  // /wt command (worktree)
+  registerCommand(registry, {
+    name: '/wt',
+    aliases: ['/worktree'],
+    description: 'Worktree operations',
+    usage: '/wt <list|next|prev|name>',
+    execute: async (args, context) => {
+      // Stub - implementation in issue #29
+      if (args.length === 0) {
+        return { success: false, error: 'Usage: /wt <list|next|prev|name>' };
+      }
+
+      const subcommand = args[0];
+
+      if (subcommand === 'list') {
+        context.notify({ type: 'info', message: 'Opening worktree list' });
+        return { success: true, message: 'Worktree list (stub)' };
+      }
+
+      if (subcommand === 'next' || subcommand === 'prev') {
+        context.notify({ type: 'info', message: `Switching to ${subcommand} worktree` });
+        return { success: true, message: `Switch ${subcommand} (stub)` };
+      }
+
+      // Treat as worktree name
+      context.notify({ type: 'info', message: `Switching to worktree: ${subcommand}` });
+      return { success: true, message: `Switch to ${subcommand} (stub)` };
+    },
+  });
+
+  // /open command (simple implementation)
+  registerCommand(registry, {
+    name: '/open',
+    aliases: ['/o'],
+    description: 'Open specific file',
+    usage: '/open <path>',
+    execute: async (args, context) => {
+      if (args.length === 0) {
+        return { success: false, error: 'Usage: /open <path>' };
+      }
+
+      const path = args.join(' ');
+
+      // Simple implementation: just update selectedPath
+      // Actual file opening happens in file opener system (#12)
+      context.setState({ selectedPath: path });
+      context.notify({ type: 'success', message: `Selected: ${path}` });
+      return { success: true, message: `Opened ${path}` };
+    },
+  });
+
+  // /copytree command (Phase 2+, stub for now)
+  registerCommand(registry, {
+    name: '/copytree',
+    aliases: ['/ct'],
+    description: 'CopyTree integration (Phase 2+)',
+    usage: '/copytree [path] [flags...]',
+    execute: async (args, context) => {
+      context.notify({
+        type: 'warning',
+        message: 'CopyTree integration coming in Phase 2',
+      });
+      return { success: false, message: 'Not implemented yet (Phase 2+)' };
+    },
+  });
+
+  return registry;
+}
+
+// ============================================================================
+// Command Execution
+// ============================================================================
+
+/**
+ * Execute command from raw input string.
+ *
+ * Parses input, finds command in registry, executes it.
+ * Returns result indicating success/failure and optional message.
+ *
+ * @param input - Raw command input (e.g., "/filter .ts" or "component")
+ * @param registry - Command registry
+ * @param context - Execution context with state and callbacks
+ * @returns Command execution result
+ */
+export async function executeCommand(
+  input: string,
+  registry: Command[],
+  context: CommandContext
+): Promise<CommandResult> {
+  try {
+    // Parse input
+    const parsed = parseCommand(input);
+
+    // Empty input → do nothing
+    if (!parsed.command) {
+      return { success: false, error: 'Empty command' };
+    }
+
+    // Find command in registry
+    const command = findCommand(parsed.command, registry);
+
+    if (!command) {
+      // Unknown command: only fall back to filter for free text (no slash)
+      // If input started with /, report as unknown command
+      const wasExplicitCommand = input.trim().startsWith('/');
+
+      if (wasExplicitCommand) {
+        return {
+          success: false,
+          error: `Unknown command: ${parsed.command}`,
+        };
+      }
+
+      // Free text → treat as filter (default behavior)
+      const filterCommand = findCommand('/filter', registry);
+      if (filterCommand) {
+        return await filterCommand.execute([input], context);
+      } else {
+        return {
+          success: false,
+          error: `Unknown command: ${parsed.command}`,
+        };
+      }
+    }
+
+    // Execute command
+    const result = await command.execute(parsed.args, context);
+    return result;
+
+  } catch (error) {
+    console.error('Command execution error:', error);
+    return {
+      success: false,
+      error: `Command failed: ${(error as Error).message}`,
+    };
+  }
+}

--- a/tests/utils/commandParser.test.ts
+++ b/tests/utils/commandParser.test.ts
@@ -1,0 +1,734 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  parseCommand,
+  findCommand,
+  registerCommand,
+  createCommandRegistry,
+  executeCommand,
+  type Command,
+  type CommandContext,
+} from '../../src/utils/commandParser.js';
+
+describe('parseCommand', () => {
+  it('parses explicit command with args', () => {
+    const parsed = parseCommand('/filter .ts');
+    expect(parsed.command).toBe('/filter');
+    expect(parsed.args).toEqual(['.ts']);
+    expect(parsed.rawInput).toBe('/filter .ts');
+  });
+
+  it('parses explicit command without args', () => {
+    const parsed = parseCommand('/changed');
+    expect(parsed.command).toBe('/changed');
+    expect(parsed.args).toEqual([]);
+  });
+
+  it('parses command with multiple args', () => {
+    const parsed = parseCommand('/git modified');
+    expect(parsed.command).toBe('/git');
+    expect(parsed.args).toEqual(['modified']);
+  });
+
+  it('treats free text as /filter command', () => {
+    const parsed = parseCommand('component');
+    expect(parsed.command).toBe('/filter');
+    expect(parsed.args).toEqual(['component']);
+  });
+
+  it('treats multi-word free text as /filter', () => {
+    const parsed = parseCommand('src utils');
+    expect(parsed.command).toBe('/filter');
+    expect(parsed.args).toEqual(['src utils']);
+  });
+
+  it('handles empty input', () => {
+    const parsed = parseCommand('');
+    expect(parsed.command).toBe('');
+    expect(parsed.args).toEqual([]);
+  });
+
+  it('handles whitespace-only input', () => {
+    const parsed = parseCommand('   ');
+    expect(parsed.command).toBe('');
+    expect(parsed.args).toEqual([]);
+  });
+
+  it('normalizes command to lowercase', () => {
+    const parsed = parseCommand('/FILTER .ts');
+    expect(parsed.command).toBe('/filter');
+  });
+
+  it('preserves case in arguments', () => {
+    const parsed = parseCommand('/filter MyComponent');
+    expect(parsed.args).toEqual(['MyComponent']);
+  });
+});
+
+describe('findCommand', () => {
+  const mockRegistry: Command[] = [
+    {
+      name: '/filter',
+      aliases: ['/f'],
+      description: 'Filter files',
+      execute: async () => ({ success: true }),
+    },
+    {
+      name: '/git',
+      description: 'Git operations',
+      execute: async () => ({ success: true }),
+    },
+  ];
+
+  it('finds command by name', () => {
+    const cmd = findCommand('/filter', mockRegistry);
+    expect(cmd).not.toBeNull();
+    expect(cmd?.name).toBe('/filter');
+  });
+
+  it('finds command by alias', () => {
+    const cmd = findCommand('/f', mockRegistry);
+    expect(cmd).not.toBeNull();
+    expect(cmd?.name).toBe('/filter');
+  });
+
+  it('is case-insensitive', () => {
+    const cmd = findCommand('/FILTER', mockRegistry);
+    expect(cmd).not.toBeNull();
+    expect(cmd?.name).toBe('/filter');
+  });
+
+  it('returns null for unknown command', () => {
+    const cmd = findCommand('/unknown', mockRegistry);
+    expect(cmd).toBeNull();
+  });
+
+  it('finds command without slash prefix', () => {
+    const cmd = findCommand('filter', mockRegistry);
+    // Should NOT find it - must use slash
+    expect(cmd).toBeNull();
+  });
+});
+
+describe('registerCommand', () => {
+  it('registers a new command', () => {
+    const registry: Command[] = [];
+    const command: Command = {
+      name: '/test',
+      description: 'Test command',
+      execute: async () => ({ success: true }),
+    };
+
+    registerCommand(registry, command);
+    expect(registry.length).toBe(1);
+    expect(registry[0]).toBe(command);
+  });
+
+  it('throws error if command has no name', () => {
+    const registry: Command[] = [];
+    const command = {
+      name: '',
+      description: 'Test',
+      execute: async () => ({ success: true }),
+    } as Command;
+
+    expect(() => registerCommand(registry, command)).toThrow('must have a name');
+  });
+
+  it('throws error if command name missing /', () => {
+    const registry: Command[] = [];
+    const command: Command = {
+      name: 'filter',
+      description: 'Test',
+      execute: async () => ({ success: true }),
+    };
+
+    expect(() => registerCommand(registry, command)).toThrow('must start with /');
+  });
+
+  it('throws error if command has no description', () => {
+    const registry: Command[] = [];
+    const command = {
+      name: '/test',
+      description: '',
+      execute: async () => ({ success: true }),
+    } as Command;
+
+    expect(() => registerCommand(registry, command)).toThrow('must have a description');
+  });
+
+  it('throws error if command has no execute function', () => {
+    const registry: Command[] = [];
+    const command = {
+      name: '/test',
+      description: 'Test',
+    } as Command;
+
+    expect(() => registerCommand(registry, command)).toThrow('must have an execute function');
+  });
+
+  it('warns and overwrites duplicate command', () => {
+    const registry: Command[] = [];
+    const command1: Command = {
+      name: '/test',
+      description: 'Test 1',
+      execute: async () => ({ success: true, message: '1' }),
+    };
+    const command2: Command = {
+      name: '/test',
+      description: 'Test 2',
+      execute: async () => ({ success: true, message: '2' }),
+    };
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    registerCommand(registry, command1);
+    registerCommand(registry, command2);
+
+    expect(registry.length).toBe(1);
+    expect(registry[0]).toBe(command2);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('already registered'));
+
+    warnSpy.mockRestore();
+  });
+
+  it('throws error if alias conflicts with existing command', () => {
+    const registry: Command[] = [];
+    const command1: Command = {
+      name: '/filter',
+      description: 'Filter',
+      execute: async () => ({ success: true }),
+    };
+    const command2: Command = {
+      name: '/search',
+      aliases: ['/filter'],
+      description: 'Search',
+      execute: async () => ({ success: true }),
+    };
+
+    registerCommand(registry, command1);
+    expect(() => registerCommand(registry, command2)).toThrow('conflicts with existing command');
+  });
+
+  it('throws error if alias conflicts with existing alias', () => {
+    const registry: Command[] = [];
+    const command1: Command = {
+      name: '/filter',
+      aliases: ['/f'],
+      description: 'Filter',
+      execute: async () => ({ success: true }),
+    };
+    const command2: Command = {
+      name: '/search',
+      aliases: ['/f'],
+      description: 'Search',
+      execute: async () => ({ success: true }),
+    };
+
+    registerCommand(registry, command1);
+    expect(() => registerCommand(registry, command2)).toThrow('conflicts with existing command');
+  });
+});
+
+describe('createCommandRegistry', () => {
+  it('creates registry with built-in commands', () => {
+    const registry = createCommandRegistry();
+    expect(registry.length).toBeGreaterThan(0);
+  });
+
+  it('includes /filter command', () => {
+    const registry = createCommandRegistry();
+    const cmd = findCommand('/filter', registry);
+    expect(cmd).not.toBeNull();
+    expect(cmd?.name).toBe('/filter');
+  });
+
+  it('includes /git command', () => {
+    const registry = createCommandRegistry();
+    const cmd = findCommand('/git', registry);
+    expect(cmd).not.toBeNull();
+  });
+
+  it('includes /changed command', () => {
+    const registry = createCommandRegistry();
+    const cmd = findCommand('/changed', registry);
+    expect(cmd).not.toBeNull();
+  });
+
+  it('includes /wt command', () => {
+    const registry = createCommandRegistry();
+    const cmd = findCommand('/wt', registry);
+    expect(cmd).not.toBeNull();
+  });
+
+  it('includes /open command', () => {
+    const registry = createCommandRegistry();
+    const cmd = findCommand('/open', registry);
+    expect(cmd).not.toBeNull();
+  });
+
+  it('supports command aliases', () => {
+    const registry = createCommandRegistry();
+    const cmd = findCommand('/f', registry); // Alias for /filter
+    expect(cmd).not.toBeNull();
+    expect(cmd?.name).toBe('/filter');
+  });
+
+  it('supports /g alias for /git', () => {
+    const registry = createCommandRegistry();
+    const cmd = findCommand('/g', registry);
+    expect(cmd).not.toBeNull();
+    expect(cmd?.name).toBe('/git');
+  });
+
+  it('supports /c alias for /changed', () => {
+    const registry = createCommandRegistry();
+    const cmd = findCommand('/c', registry);
+    expect(cmd).not.toBeNull();
+    expect(cmd?.name).toBe('/changed');
+  });
+
+  it('supports /worktree alias for /wt', () => {
+    const registry = createCommandRegistry();
+    const cmd = findCommand('/worktree', registry);
+    expect(cmd).not.toBeNull();
+    expect(cmd?.name).toBe('/wt');
+  });
+
+  it('supports /o alias for /open', () => {
+    const registry = createCommandRegistry();
+    const cmd = findCommand('/o', registry);
+    expect(cmd).not.toBeNull();
+    expect(cmd?.name).toBe('/open');
+  });
+
+  it('supports /ct alias for /copytree', () => {
+    const registry = createCommandRegistry();
+    const cmd = findCommand('/ct', registry);
+    expect(cmd).not.toBeNull();
+    expect(cmd?.name).toBe('/copytree');
+  });
+});
+
+describe('executeCommand', () => {
+  // Mock context
+  function createMockContext(): CommandContext {
+    return {
+      state: {} as any,
+      setState: vi.fn(),
+      config: {} as any,
+      notify: vi.fn(),
+    };
+  }
+
+  it('executes explicit command', async () => {
+    const executeFn = vi.fn(async () => ({ success: true, message: 'OK' }));
+    const registry: Command[] = [
+      {
+        name: '/test',
+        description: 'Test',
+        execute: executeFn,
+      },
+    ];
+    const context = createMockContext();
+
+    const result = await executeCommand('/test arg1', registry, context);
+
+    expect(result.success).toBe(true);
+    expect(executeFn).toHaveBeenCalledWith(['arg1'], context);
+  });
+
+  it('passes multiple args to command', async () => {
+    const executeFn = vi.fn(async () => ({ success: true }));
+    const registry: Command[] = [
+      {
+        name: '/test',
+        description: 'Test',
+        execute: executeFn,
+      },
+    ];
+    const context = createMockContext();
+
+    await executeCommand('/test arg1 arg2 arg3', registry, context);
+
+    expect(executeFn).toHaveBeenCalledWith(['arg1', 'arg2', 'arg3'], context);
+  });
+
+  it('resolves command aliases', async () => {
+    const executeFn = vi.fn(async () => ({ success: true }));
+    const registry: Command[] = [
+      {
+        name: '/filter',
+        aliases: ['/f'],
+        description: 'Filter',
+        execute: executeFn,
+      },
+    ];
+    const context = createMockContext();
+
+    await executeCommand('/f pattern', registry, context);
+
+    expect(executeFn).toHaveBeenCalledWith(['pattern'], context);
+  });
+
+  it('treats free text as /filter command', async () => {
+    const filterFn = vi.fn(async () => ({ success: true }));
+    const registry: Command[] = [
+      {
+        name: '/filter',
+        description: 'Filter',
+        execute: filterFn,
+      },
+    ];
+    const context = createMockContext();
+
+    await executeCommand('component', registry, context);
+
+    expect(filterFn).toHaveBeenCalledWith(['component'], context);
+  });
+
+  it('returns error for unknown slash command (not treated as filter)', async () => {
+    const filterFn = vi.fn(async () => ({ success: true }));
+    const registry: Command[] = [
+      {
+        name: '/filter',
+        description: 'Filter',
+        execute: filterFn,
+      },
+    ];
+    const context = createMockContext();
+
+    const result = await executeCommand('/unknown test', registry, context);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Unknown command: /unknown');
+    expect(filterFn).not.toHaveBeenCalled();
+  });
+
+  it('returns error for unknown command when /filter is missing', async () => {
+    const registry: Command[] = [
+      {
+        name: '/git',
+        description: 'Git',
+        execute: async () => ({ success: true }),
+      },
+    ];
+    const context = createMockContext();
+
+    const result = await executeCommand('/unknown', registry, context);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Unknown command: /unknown');
+  });
+
+  it('returns error for empty input', async () => {
+    const registry: Command[] = [];
+    const context = createMockContext();
+
+    const result = await executeCommand('', registry, context);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Empty command');
+  });
+
+  it('handles command execution errors', async () => {
+    const executeFn = vi.fn(async () => {
+      throw new Error('Test error');
+    });
+    const registry: Command[] = [
+      {
+        name: '/test',
+        description: 'Test',
+        execute: executeFn,
+      },
+    ];
+    const context = createMockContext();
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await executeCommand('/test', registry, context);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Command failed');
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+
+  it('returns command result on success', async () => {
+    const executeFn = vi.fn(async () => ({
+      success: true,
+      message: 'Command executed successfully',
+    }));
+    const registry: Command[] = [
+      {
+        name: '/test',
+        description: 'Test',
+        execute: executeFn,
+      },
+    ];
+    const context = createMockContext();
+
+    const result = await executeCommand('/test', registry, context);
+
+    expect(result.success).toBe(true);
+    expect(result.message).toBe('Command executed successfully');
+  });
+
+  it('returns command result on failure', async () => {
+    const executeFn = vi.fn(async () => ({
+      success: false,
+      error: 'Invalid arguments',
+    }));
+    const registry: Command[] = [
+      {
+        name: '/test',
+        description: 'Test',
+        execute: executeFn,
+      },
+    ];
+    const context = createMockContext();
+
+    const result = await executeCommand('/test', registry, context);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Invalid arguments');
+  });
+});
+
+describe('Built-in commands integration', () => {
+  function createMockContext(): CommandContext {
+    return {
+      state: {
+        filterActive: false,
+        filterQuery: '',
+        filteredPaths: [],
+        selectedPath: '',
+      } as any,
+      setState: vi.fn(),
+      config: {} as any,
+      notify: vi.fn(),
+    };
+  }
+
+  describe('/filter command', () => {
+    it('sets filter state when given a pattern', async () => {
+      const registry = createCommandRegistry();
+      const context = createMockContext();
+
+      const result = await executeCommand('/filter .ts', registry, context);
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('Filtering by: .ts');
+      expect(context.setState).toHaveBeenCalledWith({
+        filterActive: true,
+        filterQuery: '.ts',
+      });
+      expect(context.notify).toHaveBeenCalledWith({
+        type: 'info',
+        message: 'Filter: .ts',
+      });
+    });
+
+    it('clears filter when given "clear" argument', async () => {
+      const registry = createCommandRegistry();
+      const context = createMockContext();
+
+      const result = await executeCommand('/filter clear', registry, context);
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('Filter cleared');
+      expect(context.setState).toHaveBeenCalledWith({
+        filterActive: false,
+        filterQuery: '',
+        filteredPaths: [],
+      });
+      expect(context.notify).toHaveBeenCalledWith({
+        type: 'info',
+        message: 'Filter cleared',
+      });
+    });
+
+    it('returns error when no arguments provided', async () => {
+      const registry = createCommandRegistry();
+      const context = createMockContext();
+
+      const result = await executeCommand('/filter', registry, context);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Usage');
+    });
+  });
+
+  describe('/git command', () => {
+    it('sets git filter for valid status', async () => {
+      const registry = createCommandRegistry();
+      const context = createMockContext();
+
+      const result = await executeCommand('/git modified', registry, context);
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('Filtering by git status: modified');
+      expect(context.setState).toHaveBeenCalledWith({
+        filterActive: true,
+        filterQuery: 'git:modified',
+      });
+      expect(context.notify).toHaveBeenCalledWith({
+        type: 'info',
+        message: 'Git filter: modified',
+      });
+    });
+
+    it('returns error for invalid status', async () => {
+      const registry = createCommandRegistry();
+      const context = createMockContext();
+
+      const result = await executeCommand('/git invalid', registry, context);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Usage');
+    });
+
+    it('returns error when no arguments provided', async () => {
+      const registry = createCommandRegistry();
+      const context = createMockContext();
+
+      const result = await executeCommand('/git', registry, context);
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('/changed command', () => {
+    it('sets filter for any git changes', async () => {
+      const registry = createCommandRegistry();
+      const context = createMockContext();
+
+      const result = await executeCommand('/changed', registry, context);
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('Showing all changed files');
+      expect(context.setState).toHaveBeenCalledWith({
+        filterActive: true,
+        filterQuery: 'git:any',
+      });
+      expect(context.notify).toHaveBeenCalledWith({
+        type: 'info',
+        message: 'Showing all changed files',
+      });
+    });
+  });
+
+  describe('/open command', () => {
+    it('sets selected path', async () => {
+      const registry = createCommandRegistry();
+      const context = createMockContext();
+
+      const result = await executeCommand('/open src/App.tsx', registry, context);
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('Opened src/App.tsx');
+      expect(context.setState).toHaveBeenCalledWith({
+        selectedPath: 'src/App.tsx',
+      });
+      expect(context.notify).toHaveBeenCalledWith({
+        type: 'success',
+        message: 'Selected: src/App.tsx',
+      });
+    });
+
+    it('handles paths with spaces', async () => {
+      const registry = createCommandRegistry();
+      const context = createMockContext();
+
+      const result = await executeCommand('/open my file.txt', registry, context);
+
+      expect(result.success).toBe(true);
+      expect(context.setState).toHaveBeenCalledWith({
+        selectedPath: 'my file.txt',
+      });
+    });
+
+    it('returns error when no path provided', async () => {
+      const registry = createCommandRegistry();
+      const context = createMockContext();
+
+      const result = await executeCommand('/open', registry, context);
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('/wt command', () => {
+    it('handles list subcommand', async () => {
+      const registry = createCommandRegistry();
+      const context = createMockContext();
+
+      const result = await executeCommand('/wt list', registry, context);
+
+      expect(result.success).toBe(true);
+      expect(context.notify).toHaveBeenCalledWith({
+        type: 'info',
+        message: 'Opening worktree list',
+      });
+    });
+
+    it('handles next subcommand', async () => {
+      const registry = createCommandRegistry();
+      const context = createMockContext();
+
+      const result = await executeCommand('/wt next', registry, context);
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('Switch next (stub)');
+      expect(context.notify).toHaveBeenCalledWith({
+        type: 'info',
+        message: 'Switching to next worktree',
+      });
+    });
+
+    it('handles prev subcommand', async () => {
+      const registry = createCommandRegistry();
+      const context = createMockContext();
+
+      const result = await executeCommand('/wt prev', registry, context);
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('Switch prev (stub)');
+      expect(context.notify).toHaveBeenCalledWith({
+        type: 'info',
+        message: 'Switching to prev worktree',
+      });
+    });
+
+    it('handles /worktree alias', async () => {
+      const registry = createCommandRegistry();
+      const context = createMockContext();
+
+      const result = await executeCommand('/worktree list', registry, context);
+
+      expect(result.success).toBe(true);
+      expect(context.notify).toHaveBeenCalledWith({
+        type: 'info',
+        message: 'Opening worktree list',
+      });
+    });
+
+    it('handles worktree name', async () => {
+      const registry = createCommandRegistry();
+      const context = createMockContext();
+
+      const result = await executeCommand('/wt main', registry, context);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('returns error when no arguments provided', async () => {
+      const registry = createCommandRegistry();
+      const context = createMockContext();
+
+      const result = await executeCommand('/wt', registry, context);
+
+      expect(result.success).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements extensible command parser and execution system with registry for slash commands (/filter, /git, /wt, /open, /copytree). Supports command aliases, free text defaulting to /filter, and pluggable command registration for future extensions.

Closes #22

## Changes Made

- Add command parser with type definitions and interfaces
- Implement command registry with validation and duplicate checking
- Create built-in commands (/filter, /git, /changed, /wt, /open, /copytree)
- Add comprehensive test suite with 60 tests
- Support command aliases and free text defaulting to /filter
- Fix duplicate detection to only check primary names, not aliases
- Fix fallback behavior to reject slash-prefixed typos as unknown commands

## Implementation Notes

**Context & rationale:**
- Created extensible command parser and registry system for slash commands
- Free text without "/" defaults to /filter for better UX (no need to type /filter every time)
- Commands use filterQuery with prefix patterns (e.g., "git:modified") rather than separate state properties
- Stub implementations allow infrastructure testing while leaving detailed logic for future issues

**Implementation details:**
- Created src/utils/commandParser.ts with complete command system:
  - Type definitions: Command, CommandExecutor, CommandContext, CommandResult, ParsedCommand
  - parseCommand(): Parses input, treats free text as /filter
  - findCommand(): Case-insensitive lookup with alias support
  - registerCommand(): Validation and duplicate checking
  - createCommandRegistry(): Built-in commands (/filter, /git, /changed, /wt, /open, /copytree)
  - executeCommand(): Main execution flow with error handling
- Created comprehensive test suite: tests/utils/commandParser.test.ts (60 tests, all passing)
- Commands registered: /filter (/f), /git (/g), /changed (/c), /wt (/worktree), /open (/o), /copytree (/ct)
- Stub implementations allow future issues to add detailed logic without changing infrastructure

## Follow-up Tasks

- Issue #25: Implement actual /filter logic (fuzzy matching, pattern handling)
- Issue #26: Implement git status filtering logic for /git and /changed commands
- Issue #29: Implement worktree operations for /wt command
- Phase 2+: Implement CopyTree integration for /copytree command