### PR TITLE
Implement command system and filter slash commands

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,12 @@ import { Box, Text } from 'ink';
 import { Header } from './components/Header.js';
 import { TreeView } from './components/TreeView.js';
 import { StatusBar } from './components/StatusBar.js';
+import { CommandBar } from './components/CommandBar.js';
 import { DEFAULT_CONFIG } from './types/index.js';
 import type { YellowwoodConfig, TreeNode, Notification } from './types/index.js';
+import { executeCommand } from './commands/index.js';
+import type { CommandContext } from './commands/index.js';
+import { useKeyboard } from './hooks/useKeyboard.js';
 
 interface AppProps {
   cwd: string;
@@ -13,9 +17,19 @@ interface AppProps {
 const App: React.FC<AppProps> = ({ cwd }) => {
   const [config] = useState<YellowwoodConfig>(DEFAULT_CONFIG);
   const [fileTree, setFileTree] = useState<TreeNode[]>([]);
+  const [originalFileTree, setOriginalFileTree] = useState<TreeNode[]>([]);
   const [selectedPath, setSelectedPath] = useState<string>('');
   const [notification, setNotification] = useState<Notification | null>(null);
   const [loading, setLoading] = useState(true);
+
+  // Command bar state
+  const [commandBarActive, setCommandBarActive] = useState(false);
+  const [commandBarInput, setCommandBarInput] = useState('');
+  const [commandHistory, setCommandHistory] = useState<string[]>([]);
+
+  // Filter state
+  const [filterActive, setFilterActive] = useState(false);
+  const [filterQuery, setFilterQuery] = useState('');
 
   useEffect(() => {
     // TODO: Load configuration from cosmiconfig
@@ -23,6 +37,125 @@ const App: React.FC<AppProps> = ({ cwd }) => {
     // TODO: Set up file watcher
     setLoading(false);
   }, [cwd]);
+
+  // Auto-dismiss notifications after 3 seconds
+  useEffect(() => {
+    if (notification) {
+      const timer = setTimeout(() => {
+        setNotification(null);
+      }, 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [notification]);
+
+  // Keep originalFileTree in sync with fileTree when filter is not active
+  useEffect(() => {
+    if (!filterActive && fileTree.length > 0) {
+      setOriginalFileTree(fileTree);
+    }
+  }, [filterActive, fileTree]);
+
+  // Restore original tree when filter is cleared
+  useEffect(() => {
+    if (!filterActive && originalFileTree.length > 0) {
+      setFileTree(originalFileTree);
+    }
+  }, [filterActive, originalFileTree]);
+
+  // Handle command bar open/close
+  const handleOpenCommandBar = () => {
+    setCommandBarActive(true);
+    setCommandBarInput('');
+  };
+
+  const handleCloseCommandBar = () => {
+    setCommandBarActive(false);
+    setCommandBarInput('');
+  };
+
+  // Handle filter clear (ESC key when filter is active)
+  const handleClearFilter = () => {
+    if (filterActive) {
+      setFilterActive(false);
+      setFilterQuery('');
+      setFileTree(originalFileTree);
+      setNotification({
+        type: 'info',
+        message: 'Filter cleared',
+      });
+    } else if (commandBarActive) {
+      // ESC in command bar closes it
+      handleCloseCommandBar();
+    }
+  };
+
+  // Execute command from command bar
+  const handleCommandSubmit = async (input: string) => {
+    // Close command bar
+    setCommandBarActive(false);
+
+    // Add to history (most recent first)
+    setCommandHistory(prev => [input, ...prev.filter(cmd => cmd !== input)].slice(0, 50));
+
+    // Build command context
+    // Use the current originalFileTree if we have one, otherwise use fileTree
+    const treeForCommands = originalFileTree.length > 0 ? originalFileTree : fileTree;
+
+    const context: CommandContext = {
+      state: {
+        fileTree,
+        expandedFolders: new Set(),
+        selectedPath,
+        cursorPosition: 0,
+        showPreview: false,
+        showHelp: false,
+        contextMenuOpen: false,
+        contextMenuPosition: { x: 0, y: 0 },
+        filterActive,
+        filterQuery,
+        filteredPaths: [],
+        gitStatus: new Map(),
+        gitEnabled: config.showGitStatus,
+        notification,
+        commandBarActive,
+        commandBarInput,
+        commandHistory,
+        config,
+      },
+      originalFileTree: treeForCommands,
+      setFilterActive: (active: boolean) => {
+        setFilterActive(active);
+        if (!active) {
+          setFilterQuery('');
+        }
+      },
+      setFilterQuery,
+      setFileTree: (tree: TreeNode[]) => {
+        setFileTree(tree);
+      },
+      notify: setNotification,
+      addToHistory: (cmd: string) => {
+        setCommandHistory(prev => [cmd, ...prev.filter(c => c !== cmd)].slice(0, 50));
+      },
+    };
+
+    // Execute command
+    const result = await executeCommand(input, context);
+
+    // Show notification if command provided one
+    if (result.notification) {
+      setNotification(result.notification);
+    }
+
+    // Clear input
+    setCommandBarInput('');
+  };
+
+  // Set up keyboard handlers
+  useKeyboard({
+    onOpenCommandBar: handleOpenCommandBar,
+    onClearFilter: handleClearFilter,
+  });
 
   if (loading) {
     return (
@@ -34,7 +167,7 @@ const App: React.FC<AppProps> = ({ cwd }) => {
 
   return (
     <Box flexDirection="column" height="100%">
-      <Header cwd={cwd} filterActive={false} filterQuery="" />
+      <Header cwd={cwd} filterActive={filterActive} filterQuery={filterQuery} />
       <Box flexGrow={1}>
         <TreeView
           fileTree={fileTree}
@@ -47,6 +180,14 @@ const App: React.FC<AppProps> = ({ cwd }) => {
         notification={notification}
         fileCount={fileTree.length}
         modifiedCount={0}
+      />
+      <CommandBar
+        active={commandBarActive}
+        input={commandBarInput}
+        history={commandHistory}
+        onInputChange={setCommandBarInput}
+        onSubmit={handleCommandSubmit}
+        onCancel={handleCloseCommandBar}
       />
     </Box>
   );

--- a/src/commands/filter.ts
+++ b/src/commands/filter.ts
@@ -1,0 +1,111 @@
+import type { CommandDefinition, CommandContext, CommandResult } from './types.js';
+import type { TreeNode } from '../types/index.js';
+import { filterTreeByName } from '../utils/filter.js';
+
+/**
+ * Count total number of files in a tree (not directories).
+ */
+function countFiles(tree: TreeNode[]): number {
+  let count = 0;
+
+  function traverse(nodes: TreeNode[]) {
+    for (const node of nodes) {
+      if (node.type === 'file') {
+        count++;
+      }
+      if (node.children) {
+        traverse(node.children);
+      }
+    }
+  }
+
+  traverse(tree);
+  return count;
+}
+
+/**
+ * Filter command: /filter <pattern>
+ * Alias: /f <pattern>
+ *
+ * Filters the file tree by name using fuzzy matching.
+ * Preserves folder hierarchy so users can see context.
+ */
+export const filterCommand: CommandDefinition = {
+  name: 'filter',
+  aliases: ['f'],
+  description: 'Filter files by name pattern (fuzzy matching)',
+  usage: '/filter <pattern> | /filter clear',
+  examples: [
+    '/filter component',
+    '/f .ts',
+    '/filter src/util',
+    '/filter clear',
+  ],
+
+  async execute(args: string[], context: CommandContext): Promise<CommandResult> {
+    const { originalFileTree, setFilterActive, setFilterQuery, setFileTree, notify } = context;
+
+    // Handle /filter clear or /filter with no args
+    if (args.length === 0 || args[0] === 'clear') {
+      setFilterActive(false);
+      setFilterQuery('');
+      // Note: We don't restore the original tree here - that should be handled
+      // by the app logic that maintains both filtered and unfiltered trees
+      notify({
+        type: 'info',
+        message: 'Filter cleared',
+      });
+
+      return {
+        success: true,
+        notification: {
+          type: 'info',
+          message: 'Filter cleared',
+        },
+      };
+    }
+
+    // Join all args to support patterns with spaces
+    const pattern = args.join(' ');
+
+    // Apply filter using utility - always filter from original unfiltered tree
+    const filteredTree = filterTreeByName(originalFileTree, pattern);
+    const fileCount = countFiles(filteredTree);
+
+    // Empty result = no matches
+    if (fileCount === 0) {
+      setFilterActive(true);
+      setFilterQuery(pattern);
+      setFileTree(filteredTree); // Empty tree
+
+      const notification = {
+        type: 'warning' as const,
+        message: `No files match "${pattern}"`,
+      };
+
+      notify(notification);
+
+      return {
+        success: true,
+        notification,
+      };
+    }
+
+    // Success - show filtered tree
+    setFilterActive(true);
+    setFilterQuery(pattern);
+    setFileTree(filteredTree);
+
+    const notification = {
+      type: 'success' as const,
+      message: `Filtered to ${fileCount} file${fileCount === 1 ? '' : 's'}`,
+    };
+
+    notify(notification);
+
+    return {
+      success: true,
+      notification,
+    };
+  },
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,0 +1,147 @@
+import type { CommandDefinition, CommandContext, CommandResult } from './types.js';
+import { filterCommand } from './filter.js';
+
+/**
+ * All registered commands.
+ * Add new command modules here to make them available.
+ */
+const allCommands: CommandDefinition[] = [
+  filterCommand,
+  // Add more commands here as they're implemented
+];
+
+/**
+ * Command registry: maps command names and aliases to their definitions.
+ * Built once at module load time for O(1) lookups.
+ */
+const commandRegistry = new Map<string, CommandDefinition>();
+
+// Populate registry with all commands and their aliases
+for (const command of allCommands) {
+  // Register primary name
+  commandRegistry.set(command.name.toLowerCase(), command);
+
+  // Register all aliases
+  if (command.aliases) {
+    for (const alias of command.aliases) {
+      commandRegistry.set(alias.toLowerCase(), command);
+    }
+  }
+}
+
+/**
+ * Parse a command input string into command name and arguments.
+ *
+ * @param input - Raw command input (may or may not have leading /)
+ * @returns Object with command name and arguments array
+ *
+ * @example
+ * parseCommand('/filter component') // { command: 'filter', args: ['component'] }
+ * parseCommand('f .ts') // { command: 'f', args: ['.ts'] }
+ * parseCommand('filter') // { command: 'filter', args: [] }
+ */
+export function parseCommand(input: string): { command: string; args: string[] } {
+  // Remove leading slash if present
+  const trimmed = input.trim();
+  const normalized = trimmed.startsWith('/') ? trimmed.slice(1) : trimmed;
+
+  // Split on whitespace
+  const parts = normalized.split(/\s+/).filter(part => part.length > 0);
+
+  if (parts.length === 0) {
+    return { command: '', args: [] };
+  }
+
+  const [command, ...args] = parts;
+  return { command: command.toLowerCase(), args };
+}
+
+/**
+ * Execute a command string with the given context.
+ *
+ * @param input - Command input string (e.g., "/filter component" or "f .ts")
+ * @param context - Command execution context with state and setters
+ * @returns Promise resolving to command result
+ *
+ * @example
+ * await executeCommand('/filter .ts', context)
+ * await executeCommand('f component', context)
+ * await executeCommand('component', context) // implicit filter
+ */
+export async function executeCommand(
+  input: string,
+  context: CommandContext
+): Promise<CommandResult> {
+  const { command, args } = parseCommand(input);
+
+  // Empty command
+  if (!command) {
+    return {
+      success: false,
+      error: 'Empty command',
+      notification: {
+        type: 'error',
+        message: 'No command entered',
+      },
+    };
+  }
+
+  // Look up command by name or alias
+  const commandDef = commandRegistry.get(command.toLowerCase());
+
+  if (!commandDef) {
+    // Free text without command = implicit /filter
+    // This allows users to just type "component" instead of "/filter component"
+    const filterDef = commandRegistry.get('filter');
+    if (filterDef) {
+      // Reconstruct the full input as filter args (include the "command" part)
+      const filterArgs = [command, ...args];
+      return await filterDef.execute(filterArgs, context);
+    }
+
+    // If somehow filter command isn't registered, return error
+    return {
+      success: false,
+      error: `Unknown command: ${command}`,
+      notification: {
+        type: 'error',
+        message: `Unknown command: ${command}`,
+      },
+    };
+  }
+
+  // Execute the command
+  try {
+    const result = await commandDef.execute(args, context);
+    return result;
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return {
+      success: false,
+      error: errorMessage,
+      notification: {
+        type: 'error',
+        message: `Command failed: ${errorMessage}`,
+      },
+    };
+  }
+}
+
+/**
+ * Get all registered command definitions.
+ * Useful for help/documentation features.
+ */
+export function getAllCommands(): CommandDefinition[] {
+  return allCommands;
+}
+
+/**
+ * Get a specific command definition by name or alias.
+ * Returns undefined if command not found.
+ */
+export function getCommand(nameOrAlias: string): CommandDefinition | undefined {
+  return commandRegistry.get(nameOrAlias.toLowerCase());
+}
+
+// Export command types for use by other modules
+export type { CommandDefinition, CommandContext, CommandResult } from './types.js';

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -1,0 +1,71 @@
+import type { TreeNode, Notification, YellowwoodState } from '../types/index.js';
+
+/**
+ * Context passed to command execution.
+ * Provides access to current state and state update functions.
+ */
+export interface CommandContext {
+  /** Current application state */
+  state: YellowwoodState;
+
+  /** Original unfiltered file tree (for filter commands to operate on) */
+  originalFileTree: TreeNode[];
+
+  /** Update filter active status */
+  setFilterActive: (active: boolean) => void;
+
+  /** Update filter query string */
+  setFilterQuery: (query: string) => void;
+
+  /** Update the file tree (for filtered results) */
+  setFileTree: (tree: TreeNode[]) => void;
+
+  /** Show a notification to the user */
+  notify: (notification: Notification) => void;
+
+  /** Add command to history */
+  addToHistory: (command: string) => void;
+}
+
+/**
+ * Result returned from command execution.
+ * Commands can return partial state updates or just success/failure.
+ */
+export interface CommandResult {
+  /** Whether the command executed successfully */
+  success: boolean;
+
+  /** Optional notification to display */
+  notification?: Notification;
+
+  /** Optional error message if command failed */
+  error?: string;
+}
+
+/**
+ * Definition of a slash command.
+ */
+export interface CommandDefinition {
+  /** Primary command name (without leading /) */
+  name: string;
+
+  /** Alternative names for the command */
+  aliases?: string[];
+
+  /** Human-readable description */
+  description: string;
+
+  /** Usage examples or syntax help */
+  usage?: string;
+
+  /** Example invocations */
+  examples?: string[];
+
+  /**
+   * Execute the command with given arguments.
+   * @param args - Command arguments (split by whitespace)
+   * @param context - Command execution context
+   * @returns Result indicating success/failure and any state updates
+   */
+  execute: (args: string[], context: CommandContext) => Promise<CommandResult>;
+}

--- a/tests/commands/filter.test.ts
+++ b/tests/commands/filter.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi } from 'vitest';
+import { filterCommand } from '../../src/commands/filter.js';
+import type { CommandContext } from '../../src/commands/types.js';
+import type { TreeNode, YellowwoodState } from '../../src/types/index.js';
+import { DEFAULT_CONFIG } from '../../src/types/index.js';
+
+// Helper to create test nodes
+function createFile(name: string, path: string): TreeNode {
+  return {
+    name,
+    path,
+    type: 'file',
+    depth: 0,
+  };
+}
+
+function createFolder(name: string, path: string, children: TreeNode[]): TreeNode {
+  return {
+    name,
+    path,
+    type: 'directory',
+    depth: 0,
+    children,
+  };
+}
+
+// Helper to create test context with mocks
+function createTestContext(tree: TreeNode[] = []): CommandContext {
+  const state: YellowwoodState = {
+    fileTree: tree,
+    expandedFolders: new Set(),
+    selectedPath: '',
+    cursorPosition: 0,
+    showPreview: false,
+    showHelp: false,
+    contextMenuOpen: false,
+    contextMenuPosition: { x: 0, y: 0 },
+    filterActive: false,
+    filterQuery: '',
+    filteredPaths: [],
+    gitStatus: new Map(),
+    gitEnabled: true,
+    notification: null,
+    commandBarActive: false,
+    commandBarInput: '',
+    commandHistory: [],
+    config: DEFAULT_CONFIG,
+  };
+
+  return {
+    state,
+    originalFileTree: tree,
+    setFilterActive: vi.fn(),
+    setFilterQuery: vi.fn(),
+    setFileTree: vi.fn(),
+    notify: vi.fn(),
+    addToHistory: vi.fn(),
+  };
+}
+
+describe('filterCommand', () => {
+  it('has correct name and aliases', () => {
+    expect(filterCommand.name).toBe('filter');
+    expect(filterCommand.aliases).toContain('f');
+  });
+
+  it('has description and usage', () => {
+    expect(filterCommand.description).toBeTruthy();
+    expect(filterCommand.usage).toBeTruthy();
+  });
+
+  describe('execute', () => {
+    it('filters tree by pattern', async () => {
+      const tree = [
+        createFile('app.ts', '/app.ts'),
+        createFile('test.ts', '/test.ts'),
+        createFile('component.tsx', '/component.tsx'),
+      ];
+      const context = createTestContext(tree);
+
+      const result = await filterCommand.execute(['app'], context);
+
+      expect(result.success).toBe(true);
+      expect(context.setFilterActive).toHaveBeenCalledWith(true);
+      expect(context.setFilterQuery).toHaveBeenCalledWith('app');
+      expect(context.setFileTree).toHaveBeenCalled();
+      expect(result.notification?.type).toBe('success');
+      expect(result.notification?.message).toContain('1 file');
+    });
+
+    it('handles patterns with spaces', async () => {
+      const tree = [
+        createFile('my component.tsx', '/my component.tsx'),
+        createFile('other.tsx', '/other.tsx'),
+      ];
+      const context = createTestContext(tree);
+
+      const result = await filterCommand.execute(['my', 'component'], context);
+
+      expect(result.success).toBe(true);
+      expect(context.setFilterQuery).toHaveBeenCalledWith('my component');
+      expect(result.notification?.type).toBe('success');
+    });
+
+    it('shows file count in success notification', async () => {
+      const tree = [
+        createFile('app.ts', '/app.ts'),
+        createFile('app.test.ts', '/app.test.ts'),
+        createFile('other.ts', '/other.ts'),
+      ];
+      const context = createTestContext(tree);
+
+      const result = await filterCommand.execute(['app'], context);
+
+      expect(result.notification?.message).toContain('2 files');
+    });
+
+    it('uses singular "file" for count of 1', async () => {
+      const tree = [
+        createFile('app.ts', '/app.ts'),
+        createFile('other.ts', '/other.ts'),
+      ];
+      const context = createTestContext(tree);
+
+      const result = await filterCommand.execute(['app'], context);
+
+      expect(result.notification?.message).toContain('1 file');
+      expect(result.notification?.message).not.toContain('files');
+    });
+
+    it('shows warning when no matches found', async () => {
+      const tree = [
+        createFile('app.ts', '/app.ts'),
+        createFile('test.ts', '/test.ts'),
+      ];
+      const context = createTestContext(tree);
+
+      const result = await filterCommand.execute(['nonexistent'], context);
+
+      expect(result.success).toBe(true);
+      expect(context.setFilterActive).toHaveBeenCalledWith(true);
+      expect(context.setFilterQuery).toHaveBeenCalledWith('nonexistent');
+      expect(result.notification?.type).toBe('warning');
+      expect(result.notification?.message).toContain('No files match');
+      expect(result.notification?.message).toContain('nonexistent');
+
+      // Verify state updates are actually called
+      expect(context.setFileTree).toHaveBeenCalled();
+      const setFileTreeCall = (context.setFileTree as any).mock.calls[0];
+      expect(setFileTreeCall[0]).toEqual([]); // Empty tree
+
+      // Verify notify was called with warning
+      expect(context.notify).toHaveBeenCalled();
+      const notifyCall = (context.notify as any).mock.calls[0];
+      expect(notifyCall[0].type).toBe('warning');
+    });
+
+    it('clears filter with "clear" argument', async () => {
+      const tree = [createFile('app.ts', '/app.ts')];
+      const context = createTestContext(tree);
+
+      const result = await filterCommand.execute(['clear'], context);
+
+      expect(result.success).toBe(true);
+      expect(context.setFilterActive).toHaveBeenCalledWith(false);
+      expect(context.setFilterQuery).toHaveBeenCalledWith('');
+      expect(result.notification?.type).toBe('info');
+      expect(result.notification?.message).toBe('Filter cleared');
+    });
+
+    it('clears filter with no arguments', async () => {
+      const tree = [createFile('app.ts', '/app.ts')];
+      const context = createTestContext(tree);
+
+      const result = await filterCommand.execute([], context);
+
+      expect(result.success).toBe(true);
+      expect(context.setFilterActive).toHaveBeenCalledWith(false);
+      expect(context.setFilterQuery).toHaveBeenCalledWith('');
+      expect(result.notification?.message).toBe('Filter cleared');
+    });
+
+    it('preserves folder hierarchy in results', async () => {
+      const tree = [
+        createFolder('src', '/src', [
+          createFile('app.ts', '/src/app.ts'),
+          createFile('test.ts', '/src/test.ts'),
+        ]),
+      ];
+      const context = createTestContext(tree);
+
+      const result = await filterCommand.execute(['app'], context);
+
+      expect(result.success).toBe(true);
+      expect(context.setFileTree).toHaveBeenCalled();
+
+      // Get the filtered tree passed to setFileTree
+      const setFileTreeCall = (context.setFileTree as any).mock.calls[0];
+      const filteredTree = setFileTreeCall[0];
+
+      expect(filteredTree).toHaveLength(1);
+      expect(filteredTree[0].type).toBe('directory');
+      expect(filteredTree[0].name).toBe('src');
+      expect(filteredTree[0].children).toHaveLength(1);
+      expect(filteredTree[0].children[0].name).toBe('app.ts');
+    });
+
+    it('handles empty tree gracefully', async () => {
+      const context = createTestContext([]);
+
+      const result = await filterCommand.execute(['anything'], context);
+
+      expect(result.success).toBe(true);
+      expect(result.notification?.type).toBe('warning');
+      expect(result.notification?.message).toContain('No files match');
+    });
+
+    it('is case-insensitive', async () => {
+      const tree = [
+        createFile('README.md', '/README.md'),
+        createFile('test.ts', '/test.ts'),
+      ];
+      const context = createTestContext(tree);
+
+      const result = await filterCommand.execute(['readme'], context);
+
+      expect(result.success).toBe(true);
+      expect(result.notification?.type).toBe('success');
+      expect(result.notification?.message).toContain('1 file');
+    });
+
+    it('counts only files, not folders', async () => {
+      const tree = [
+        createFolder('components', '/components', [
+          createFile('Button.tsx', '/components/Button.tsx'),
+          createFile('Input.tsx', '/components/Input.tsx'),
+        ]),
+      ];
+      const context = createTestContext(tree);
+
+      const result = await filterCommand.execute(['comp'], context);
+
+      // Should count 2 files (Button.tsx + Input.tsx), not 3 (folder + files)
+      // When folder name matches, it includes all children
+      expect(result.notification?.message).toContain('2 files');
+    });
+
+    it('calls notify with notification', async () => {
+      const tree = [createFile('app.ts', '/app.ts')];
+      const context = createTestContext(tree);
+
+      await filterCommand.execute(['app'], context);
+
+      expect(context.notify).toHaveBeenCalled();
+      const notification = (context.notify as any).mock.calls[0][0];
+      expect(notification.type).toBe('success');
+      expect(notification.message).toContain('1 file');
+    });
+
+    it('handles multiple filter operations', async () => {
+      const tree = [
+        createFile('app.ts', '/app.ts'),
+        createFile('test.ts', '/test.ts'),
+        createFile('component.tsx', '/component.tsx'),
+      ];
+      const context = createTestContext(tree);
+
+      // First filter
+      await filterCommand.execute(['app'], context);
+      expect(context.setFilterActive).toHaveBeenCalledWith(true);
+
+      // Second filter (different pattern)
+      await filterCommand.execute(['test'], context);
+      expect(context.setFilterQuery).toHaveBeenCalledWith('test');
+
+      // Clear filter
+      await filterCommand.execute(['clear'], context);
+      expect(context.setFilterActive).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/tests/commands/parser.test.ts
+++ b/tests/commands/parser.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi } from 'vitest';
+import { parseCommand, executeCommand, getCommand, getAllCommands } from '../../src/commands/index.js';
+import type { CommandContext } from '../../src/commands/types.js';
+import type { TreeNode, YellowwoodState } from '../../src/types/index.js';
+import { DEFAULT_CONFIG } from '../../src/types/index.js';
+
+// Helper to create minimal test context
+function createTestContext(tree: TreeNode[] = []): CommandContext {
+  const state: YellowwoodState = {
+    fileTree: tree,
+    expandedFolders: new Set(),
+    selectedPath: '',
+    cursorPosition: 0,
+    showPreview: false,
+    showHelp: false,
+    contextMenuOpen: false,
+    contextMenuPosition: { x: 0, y: 0 },
+    filterActive: false,
+    filterQuery: '',
+    filteredPaths: [],
+    gitStatus: new Map(),
+    gitEnabled: true,
+    notification: null,
+    commandBarActive: false,
+    commandBarInput: '',
+    commandHistory: [],
+    config: DEFAULT_CONFIG,
+  };
+
+  return {
+    state,
+    originalFileTree: tree,
+    setFilterActive: () => {},
+    setFilterQuery: () => {},
+    setFileTree: () => {},
+    notify: () => {},
+    addToHistory: () => {},
+  };
+}
+
+describe('parseCommand', () => {
+  it('parses command with leading slash', () => {
+    const result = parseCommand('/filter component');
+    expect(result.command).toBe('filter');
+    expect(result.args).toEqual(['component']);
+  });
+
+  it('parses command without leading slash', () => {
+    const result = parseCommand('filter component');
+    expect(result.command).toBe('filter');
+    expect(result.args).toEqual(['component']);
+  });
+
+  it('parses command with no arguments', () => {
+    const result = parseCommand('/filter');
+    expect(result.command).toBe('filter');
+    expect(result.args).toEqual([]);
+  });
+
+  it('parses command with multiple arguments', () => {
+    const result = parseCommand('/filter my component name');
+    expect(result.command).toBe('filter');
+    expect(result.args).toEqual(['my', 'component', 'name']);
+  });
+
+  it('normalizes command name to lowercase', () => {
+    const result = parseCommand('/FILTER Component');
+    expect(result.command).toBe('filter');
+    expect(result.args).toEqual(['Component']); // args preserve case
+  });
+
+  it('handles empty input', () => {
+    const result = parseCommand('');
+    expect(result.command).toBe('');
+    expect(result.args).toEqual([]);
+  });
+
+  it('handles whitespace-only input', () => {
+    const result = parseCommand('   ');
+    expect(result.command).toBe('');
+    expect(result.args).toEqual([]);
+  });
+
+  it('handles multiple spaces between arguments', () => {
+    const result = parseCommand('/filter   component   test');
+    expect(result.command).toBe('filter');
+    expect(result.args).toEqual(['component', 'test']);
+  });
+
+  it('trims leading and trailing whitespace', () => {
+    const result = parseCommand('  /filter component  ');
+    expect(result.command).toBe('filter');
+    expect(result.args).toEqual(['component']);
+  });
+});
+
+describe('executeCommand', () => {
+  it('executes filter command by name', async () => {
+    const context = createTestContext();
+    const result = await executeCommand('/filter test', context);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('executes filter command by alias', async () => {
+    const context = createTestContext();
+    const result = await executeCommand('/f test', context);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('treats free text as implicit filter', async () => {
+    const tree = [
+      { name: 'component.ts', path: '/component.ts', type: 'file' as const, depth: 0 },
+      { name: 'other.ts', path: '/other.ts', type: 'file' as const, depth: 0 },
+    ];
+    const setFilterActive = vi.fn();
+    const setFilterQuery = vi.fn();
+    const setFileTree = vi.fn();
+
+    const context: CommandContext = {
+      ...createTestContext(tree),
+      setFilterActive,
+      setFilterQuery,
+      setFileTree,
+    };
+
+    const result = await executeCommand('component', context);
+
+    // Should execute filter command with 'component' as the pattern
+    expect(result.success).toBe(true);
+    expect(setFilterActive).toHaveBeenCalledWith(true);
+    expect(setFilterQuery).toHaveBeenCalledWith('component');
+    expect(setFileTree).toHaveBeenCalled();
+  });
+
+  it('returns error for unknown command', async () => {
+    // Note: Since free text triggers implicit filter, we need a command-like input
+    // that won't match any registered commands but looks like a command attempt
+    // However, the current implementation treats ALL unknown text as implicit filter
+    // This is by design - there's no way to get "unknown command" error
+    // with the current implementation since everything falls through to filter
+
+    // This test documents the current behavior - may change in future
+    const context = createTestContext();
+    const result = await executeCommand('unknowncommand arg1 arg2', context);
+
+    // Currently this would trigger implicit filter, not an error
+    expect(result.success).toBe(true);
+  });
+
+  it('returns error for empty command', async () => {
+    const context = createTestContext();
+    const result = await executeCommand('', context);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Empty command');
+    expect(result.notification?.type).toBe('error');
+  });
+
+  it('is case-insensitive for command names', async () => {
+    const context = createTestContext();
+    const result = await executeCommand('/FILTER test', context);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('handles command execution errors', async () => {
+    const context = createTestContext();
+
+    // Override notify to throw error for testing error handling
+    const throwingContext: CommandContext = {
+      ...context,
+      notify: () => {
+        throw new Error('Test error');
+      },
+    };
+
+    const result = await executeCommand('/filter test', throwingContext);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Test error');
+    expect(result.notification?.type).toBe('error');
+  });
+});
+
+describe('getCommand', () => {
+  it('gets command by name', () => {
+    const command = getCommand('filter');
+    expect(command).toBeDefined();
+    expect(command?.name).toBe('filter');
+  });
+
+  it('gets command by alias', () => {
+    const command = getCommand('f');
+    expect(command).toBeDefined();
+    expect(command?.name).toBe('filter');
+  });
+
+  it('is case-insensitive', () => {
+    const command = getCommand('FILTER');
+    expect(command).toBeDefined();
+    expect(command?.name).toBe('filter');
+  });
+
+  it('returns undefined for unknown command', () => {
+    const command = getCommand('nonexistent');
+    expect(command).toBeUndefined();
+  });
+});
+
+describe('getAllCommands', () => {
+  it('returns all registered commands', () => {
+    const commands = getAllCommands();
+    expect(commands.length).toBeGreaterThan(0);
+
+    // Should include filter command
+    const filterCommand = commands.find(cmd => cmd.name === 'filter');
+    expect(filterCommand).toBeDefined();
+  });
+
+  it('returns commands with required properties', () => {
+    const commands = getAllCommands();
+
+    for (const command of commands) {
+      expect(command).toHaveProperty('name');
+      expect(command).toHaveProperty('description');
+      expect(command).toHaveProperty('execute');
+      expect(typeof command.execute).toBe('function');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements `/filter` and `/f` slash commands for name-based file tree filtering, along with the minimal command system infrastructure needed to support them. This PR addresses both issue #25 (filter commands) and the essential parts of issue #22 (command parser).

Closes #25

## Changes Made

- Add command system infrastructure (types, registry, parser, executor)
- Implement `/filter` and `/f` commands with fuzzy name matching
- Integrate CommandBar with command execution in App.tsx
- Add originalFileTree context to prevent filter chaining bugs
- Support implicit filtering (free text triggers /filter)
- Add comprehensive unit tests (37 tests for command system)
- Fix critical bug where filters operated on already-filtered trees
- Add state synchronization for originalFileTree

## Implementation Notes

**Context & Rationale:**
- Issue #25 required filter commands but depended on #22 (command parser) which was not yet implemented
- Implemented both minimal command system (#22) and filter commands (#25) together in this PR
- Chose to build minimal command infrastructure needed rather than block on separate #22 implementation
- CommandBar UI already existed, keyboard handlers already had support for `/` key, state types already included command fields

**Implementation Details:**
- Created command system infrastructure in `src/commands/`:
  - `types.ts`: CommandDefinition, CommandContext, CommandResult interfaces
  - `index.ts`: Command registry, parser, executeCommand function with implicit filter support
  - `filter.ts`: Implementation of `/filter` and `/f` commands with fuzzy matching
- Updated `App.tsx` to integrate command system:
  - Added state for command bar, filter, and command history
  - Maintained separate originalFileTree to allow filter clear/restore
  - Integrated useKeyboard hook for `/` and ESC key handling
  - Auto-dismiss notifications after 3 seconds
  - Built CommandContext and wired to executeCommand
- Filter command features:
  - `/filter <pattern>`: Fuzzy filter files by name, preserves folder hierarchy
  - `/f <pattern>`: Alias for filter command
  - `/filter clear` or `/filter`: Clear active filter
  - Free text without command prefix implicitly executes filter
  - Shows file count in success notification, warning when no matches
- Command parser handles implicit filtering: typing "component" executes "/filter component"

## Code Review Fixes

**Critical bug fix**: Filter command was operating on already-filtered tree instead of original tree
- Added `originalFileTree` to CommandContext
- Filter now always operates on unfiltered tree, enabling consecutive filters to work correctly
- Fixed state synchronization to keep originalFileTree updated when filter is not active

**Test coverage improvements**:
- Added assertions for state updates in "no matches" scenario
- Enhanced implicit filter test to verify state changes

## Follow-up Tasks

- Add more commands (git filter, help, etc.) using the same command system
- Consider adding command history persistence across sessions
- Add command autocomplete/suggestions in future