### PR TITLE
Implement git filter slash commands

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,6 +21,32 @@ export interface Notification {
   type: NotificationType;
 }
 
+export interface CommandContext {
+  /** Current file tree (read-only for parser) */
+  fileTree: TreeNode[];
+
+  /** Map of file paths to their git status (read-only) */
+  gitStatus: Map<string, GitStatus>;
+
+  /** Whether git is available in current repository */
+  gitEnabled: boolean;
+
+  /** Setter to update git status filter (null to clear) */
+  setGitStatusFilter: (filter: GitStatus | GitStatus[] | null) => void;
+
+  /** Setter to update filter active status */
+  setFilterActive: (active: boolean) => void;
+
+  /** Setter to update filter query display string */
+  setFilterQuery: (query: string | null) => void;
+
+  /** Setter to display notifications to user */
+  setNotification: (notification: Notification) => void;
+
+  /** Current command history for autocomplete/reference */
+  commandHistory: string[];
+}
+
 /**
  * Represents a single git worktree.
  * Git worktrees allow multiple working trees attached to the same repository,

--- a/src/utils/commandParser.ts
+++ b/src/utils/commandParser.ts
@@ -1,0 +1,262 @@
+import type { GitStatus, Notification, CommandContext, TreeNode } from '../types/index.js';
+import { filterTreeByGitStatus } from './filter.js';
+
+/**
+ * Command execution result with message to display to user.
+ */
+export interface CommandResult {
+  message: string;
+  type: 'info' | 'success' | 'error' | 'warning';
+}
+
+/**
+ * Command handler function signature.
+ */
+type CommandHandler = (args: string[], context: CommandContext) => Promise<CommandResult> | CommandResult;
+
+/**
+ * Registered command definition.
+ */
+interface CommandDefinition {
+  name: string;
+  aliases: string[];
+  description: string;
+  handler: CommandHandler;
+}
+
+/**
+ * Command parser for handling slash commands.
+ * Manages command registration, parsing, and execution.
+ */
+class CommandParser {
+  private commands: Map<string, CommandDefinition> = new Map();
+  private aliasMap: Map<string, string> = new Map();
+
+  /**
+   * Parse a command string into command name and arguments.
+   * @param input - Raw command input (e.g., "/git modified")
+   * @returns Parsed command name and arguments
+   * @throws Error if input is not a valid command format
+   */
+  parseCommand(input: string): { command: string; args: string[] } {
+    const trimmed = input.trim();
+
+    // Must start with /
+    if (!trimmed.startsWith('/')) {
+      throw new Error('Commands must start with /');
+    }
+
+    // Remove leading /
+    const commandStr = trimmed.slice(1);
+
+    // Split by spaces to get command and args
+    const parts = commandStr.split(/\s+/).filter(p => p.length > 0);
+
+    if (parts.length === 0) {
+      throw new Error('Empty command');
+    }
+
+    const [commandName, ...args] = parts;
+    return { command: commandName.toLowerCase(), args };
+  }
+
+  /**
+   * Register a command handler.
+   */
+  registerCommand(
+    name: string,
+    aliases: string[],
+    description: string,
+    handler: CommandHandler
+  ): void {
+    const lowerName = name.toLowerCase();
+
+    // Register main name
+    this.commands.set(lowerName, {
+      name: lowerName,
+      aliases: aliases.map(a => a.toLowerCase()),
+      description,
+      handler,
+    });
+
+    // Register all aliases
+    for (const alias of aliases) {
+      this.aliasMap.set(alias.toLowerCase(), lowerName);
+    }
+  }
+
+  /**
+   * Execute a command string with the given context.
+   * @param input - Raw command input (e.g., "/git modified")
+   * @param context - Command execution context
+   * @returns Command result with message
+   */
+  async executeCommand(input: string, context: CommandContext): Promise<CommandResult> {
+    try {
+      const { command, args } = this.parseCommand(input);
+
+      // Resolve alias to main command name
+      const mainCommand = this.aliasMap.get(command) || command;
+      const commandDef = this.commands.get(mainCommand);
+
+      if (!commandDef) {
+        return {
+          message: `Unknown command: ${command}. Use /help for available commands.`,
+          type: 'error',
+        };
+      }
+
+      // Execute the command handler
+      const result = await commandDef.handler(args, context);
+      return result;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        message: `Error: ${message}`,
+        type: 'error',
+      };
+    }
+  }
+}
+
+/**
+ * Global parser instance.
+ */
+const parser = new CommandParser();
+
+/**
+ * Count files in tree (excluding directories).
+ */
+function countFiles(tree: TreeNode[]): number {
+  let count = 0;
+  for (const node of tree) {
+    if (node.type === 'file') {
+      count++;
+    }
+    if (node.children) {
+      count += countFiles(node.children);
+    }
+  }
+  return count;
+}
+
+/**
+ * Register git filter commands (/git and /changed).
+ */
+function registerGitCommands(): void {
+  // /git [status] command
+  parser.registerCommand(
+    'git',
+    ['g'],
+    'Filter tree by git status (modified|added|deleted|untracked)',
+    (args, context) => {
+      // Check if git is enabled
+      if (!context.gitEnabled) {
+        return {
+          message: 'Git is not enabled. Make sure you are in a git repository and git is installed.',
+          type: 'error',
+        };
+      }
+
+      // Validate arguments
+      if (args.length === 0) {
+        return {
+          message: 'Usage: /git <status>\nAvailable statuses: modified, added, deleted, untracked',
+          type: 'error',
+        };
+      }
+
+      const status = args[0].toLowerCase();
+      const validStatuses: GitStatus[] = ['modified', 'added', 'deleted', 'untracked'];
+
+      if (!validStatuses.includes(status as GitStatus)) {
+        return {
+          message: `Invalid git status: "${status}"\nUse: /git ${validStatuses.join('|')}`,
+          type: 'error',
+        };
+      }
+
+      // Update state to apply git status filter
+      context.setGitStatusFilter(status as GitStatus);
+      context.setFilterActive(true);
+      context.setFilterQuery(`/git: ${status}`);
+
+      // Count matching files by applying filter to current tree
+      const filteredTree = filterTreeByGitStatus(context.fileTree, status as GitStatus);
+      const count = countFiles(filteredTree);
+
+      return {
+        message: `Showing ${status} files (${count} found)`,
+        type: 'success',
+      };
+    }
+  );
+
+  // /changed command (shorthand for all modified files)
+  parser.registerCommand(
+    'changed',
+    ['ch'],
+    'Show all changed files (modified, added, deleted, untracked)',
+    (args, context) => {
+      // Check if git is enabled
+      if (!context.gitEnabled) {
+        return {
+          message: 'Git is not enabled. Make sure you are in a git repository.',
+          type: 'error',
+        };
+      }
+
+      // Filter by all non-clean statuses
+      const statuses: GitStatus[] = ['modified', 'added', 'deleted', 'untracked'];
+
+      // Update state to apply git status filter
+      context.setGitStatusFilter(statuses);
+      context.setFilterActive(true);
+      context.setFilterQuery('/changed');
+
+      // Count matching files by applying filter to current tree
+      const filteredTree = filterTreeByGitStatus(context.fileTree, statuses);
+      const count = countFiles(filteredTree);
+
+      return {
+        message: `Showing all changed files (${count} found)`,
+        type: 'success',
+      };
+    }
+  );
+}
+
+// Initialize commands on module load
+registerGitCommands();
+
+/**
+ * Execute a command string with the given context.
+ * @param input - Raw command input (e.g., "/git modified")
+ * @param context - Command execution context
+ * @returns Command result with message
+ */
+export async function executeCommand(input: string, context: CommandContext): Promise<CommandResult> {
+  return parser.executeCommand(input, context);
+}
+
+/**
+ * Parse a command string into command name and arguments.
+ * @param input - Raw command input (e.g., "/git modified")
+ * @returns Parsed command name and arguments
+ */
+export function parseCommand(input: string): { command: string; args: string[] } {
+  return parser.parseCommand(input);
+}
+
+/**
+ * Register a custom command.
+ * Used for testing and extending the command system.
+ */
+export function registerCommand(
+  name: string,
+  aliases: string[],
+  description: string,
+  handler: CommandHandler
+): void {
+  parser.registerCommand(name, aliases, description, handler);
+}

--- a/tests/hooks/useFileTree.test.ts
+++ b/tests/hooks/useFileTree.test.ts
@@ -470,7 +470,7 @@ describe('useFileTree', () => {
 
     // Should return unfiltered tree on filter error
     expect(result.current.tree).toEqual(mockTree);
-    expect(consoleSpy).toHaveBeenCalledWith('Filter error:', expect.any(Error));
+    expect(consoleSpy).toHaveBeenCalledWith('Name filter error:', expect.any(Error));
 
     consoleSpy.mockRestore();
   });

--- a/tests/utils/commandParser.test.ts
+++ b/tests/utils/commandParser.test.ts
@@ -1,0 +1,452 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { parseCommand, executeCommand } from '../../src/utils/commandParser.js';
+import type { CommandContext, TreeNode, GitStatus } from '../../src/types/index.js';
+
+// Helper to create test nodes
+function createFile(name: string, path: string, gitStatus?: GitStatus): TreeNode {
+  return {
+    name,
+    path,
+    type: 'file',
+    depth: 0,
+    gitStatus,
+  };
+}
+
+function createFolder(name: string, path: string, children: TreeNode[]): TreeNode {
+  return {
+    name,
+    path,
+    type: 'directory',
+    depth: 0,
+    children,
+  };
+}
+
+// Helper to count files in tree
+function countFiles(tree: TreeNode[]): number {
+  let count = 0;
+  for (const node of tree) {
+    if (node.type === 'file') {
+      count++;
+    }
+    if (node.children) {
+      count += countFiles(node.children);
+    }
+  }
+  return count;
+}
+
+describe('parseCommand', () => {
+  it('parses /git modified correctly', () => {
+    const result = parseCommand('/git modified');
+    expect(result.command).toBe('git');
+    expect(result.args).toEqual(['modified']);
+  });
+
+  it('parses /g modified (alias) correctly', () => {
+    const result = parseCommand('/g modified');
+    expect(result.command).toBe('g');
+    expect(result.args).toEqual(['modified']);
+  });
+
+  it('parses /changed correctly', () => {
+    const result = parseCommand('/changed');
+    expect(result.command).toBe('changed');
+    expect(result.args).toEqual([]);
+  });
+
+  it('parses /ch (alias) correctly', () => {
+    const result = parseCommand('/ch');
+    expect(result.command).toBe('ch');
+    expect(result.args).toEqual([]);
+  });
+
+  it('handles mixed case command names', () => {
+    const result = parseCommand('/GIT MODIFIED');
+    expect(result.command).toBe('git');
+    expect(result.args).toEqual(['MODIFIED']);
+  });
+
+  it('handles extra spaces in input', () => {
+    const result = parseCommand('/git   modified   ');
+    expect(result.command).toBe('git');
+    expect(result.args).toEqual(['modified']);
+  });
+
+  it('throws error for input without leading slash', () => {
+    expect(() => parseCommand('git modified')).toThrow(/must start with/i);
+  });
+
+  it('throws error for empty command', () => {
+    expect(() => parseCommand('/')).toThrow(/empty command/i);
+  });
+
+  it('throws error for whitespace-only input', () => {
+    expect(() => parseCommand('/   ')).toThrow(/empty command/i);
+  });
+});
+
+describe('/git command', () => {
+  let mockContext: CommandContext;
+  let sampleTree: TreeNode[];
+  let gitStatusMap: Map<string, GitStatus>;
+
+  beforeEach(() => {
+    // Sample tree with git statuses
+    sampleTree = [
+      createFolder('src', '/src', [
+        createFile('App.tsx', '/src/App.tsx', 'modified'),
+        createFile('New.tsx', '/src/New.tsx', 'added'),
+        createFile('utils.ts', '/src/utils.ts'), // clean (no status)
+      ]),
+      createFile('README.md', '/README.md', 'modified'),
+      createFile('deleted.ts', '/deleted.ts', 'deleted'),
+      createFile('untracked.txt', '/untracked.txt', 'untracked'),
+    ];
+
+    gitStatusMap = new Map([
+      ['/src/App.tsx', 'modified'],
+      ['/src/New.tsx', 'added'],
+      ['/README.md', 'modified'],
+      ['/deleted.ts', 'deleted'],
+      ['/untracked.txt', 'untracked'],
+    ]);
+
+    mockContext = {
+      fileTree: sampleTree,
+      gitStatus: gitStatusMap,
+      gitEnabled: true,
+      setGitStatusFilter: vi.fn(),
+      setFilterActive: vi.fn(),
+      setFilterQuery: vi.fn(),
+      setNotification: vi.fn(),
+      commandHistory: [],
+    };
+  });
+
+  it('filters by modified status', async () => {
+    const result = await executeCommand('/git modified', mockContext);
+
+    expect(mockContext.setGitStatusFilter).toHaveBeenCalledWith('modified');
+    expect(mockContext.setFilterActive).toHaveBeenCalledWith(true);
+    expect(mockContext.setFilterQuery).toHaveBeenCalledWith('/git: modified');
+
+    expect(result.type).toBe('success');
+    expect(result.message).toContain('modified');
+    expect(result.message).toContain('2 found');
+  });
+
+  it('filters by added status', async () => {
+    const result = await executeCommand('/git added', mockContext);
+
+    expect(mockContext.setGitStatusFilter).toHaveBeenCalledWith('added');
+    expect(result.message).toContain('added');
+    expect(result.message).toContain('1 found');
+  });
+
+  it('filters by deleted status', async () => {
+    const result = await executeCommand('/git deleted', mockContext);
+
+    expect(mockContext.setGitStatusFilter).toHaveBeenCalledWith('deleted');
+    expect(result.message).toContain('deleted');
+  });
+
+  it('filters by untracked status', async () => {
+    const result = await executeCommand('/git untracked', mockContext);
+
+    expect(mockContext.setGitStatusFilter).toHaveBeenCalledWith('untracked');
+    expect(result.message).toContain('untracked');
+  });
+
+  it('returns error for invalid status', async () => {
+    const result = await executeCommand('/git invalid', mockContext);
+
+    expect(result.type).toBe('error');
+    expect(result.message).toContain('Invalid git status');
+    expect(result.message).toContain('invalid');
+    expect(mockContext.setGitStatusFilter).not.toHaveBeenCalled();
+  });
+
+  it('returns error for missing argument', async () => {
+    const result = await executeCommand('/git', mockContext);
+
+    expect(result.type).toBe('error');
+    expect(result.message).toContain('Usage');
+    expect(mockContext.setGitStatusFilter).not.toHaveBeenCalled();
+  });
+
+  it('returns error when git is disabled', async () => {
+    mockContext.gitEnabled = false;
+
+    const result = await executeCommand('/git modified', mockContext);
+
+    expect(result.type).toBe('error');
+    expect(result.message).toContain('Git is not enabled');
+    expect(mockContext.setGitStatusFilter).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 files found when no files match status', async () => {
+    // Create a tree where no files are staged
+    mockContext.fileTree = [createFile('file.ts', '/file.ts', 'modified')];
+    mockContext.gitStatus = new Map([['/file.ts', 'modified']]);
+
+    const result = await executeCommand('/git added', mockContext);
+
+    expect(result.message).toContain('added');
+    expect(result.message).toContain('0 found');
+    expect(result.type).toBe('success');
+  });
+
+  it('handles empty tree gracefully', async () => {
+    mockContext.fileTree = [];
+
+    const result = await executeCommand('/git modified', mockContext);
+
+    expect(result.type).toBe('success');
+    expect(result.message).toContain('0 found');
+  });
+
+  it('uses alias /g correctly', async () => {
+    const result = await executeCommand('/g modified', mockContext);
+
+    expect(mockContext.setGitStatusFilter).toHaveBeenCalledWith('modified');
+    expect(result.type).toBe('success');
+    expect(result.message).toContain('modified');
+  });
+
+  it('case-insensitive status argument', async () => {
+    const result = await executeCommand('/git MODIFIED', mockContext);
+
+    expect(result.type).toBe('success');
+    expect(mockContext.setGitStatusFilter).toHaveBeenCalledWith('modified');
+    expect(mockContext.setFilterQuery).toHaveBeenCalledWith('/git: modified');
+  });
+
+  it('ignores extra arguments', async () => {
+    const result = await executeCommand('/git modified extra args here', mockContext);
+
+    expect(result.type).toBe('success');
+    expect(mockContext.setGitStatusFilter).toHaveBeenCalledWith('modified');
+  });
+});
+
+describe('/changed command', () => {
+  let mockContext: CommandContext;
+  let sampleTree: TreeNode[];
+
+  beforeEach(() => {
+    sampleTree = [
+      createFolder('src', '/src', [
+        createFile('App.tsx', '/src/App.tsx', 'modified'),
+        createFile('New.tsx', '/src/New.tsx', 'added'),
+        createFile('utils.ts', '/src/utils.ts'), // clean
+      ]),
+      createFile('README.md', '/README.md', 'modified'),
+      createFile('deleted.ts', '/deleted.ts', 'deleted'),
+      createFile('untracked.txt', '/untracked.txt', 'untracked'),
+    ];
+
+    mockContext = {
+      fileTree: sampleTree,
+      gitStatus: new Map([
+        ['/src/App.tsx', 'modified'],
+        ['/src/New.tsx', 'added'],
+        ['/README.md', 'modified'],
+        ['/deleted.ts', 'deleted'],
+        ['/untracked.txt', 'untracked'],
+      ]),
+      gitEnabled: true,
+      setGitStatusFilter: vi.fn(),
+      setFilterActive: vi.fn(),
+      setFilterQuery: vi.fn(),
+      setNotification: vi.fn(),
+      commandHistory: [],
+    };
+  });
+
+  it('shows all changed files', async () => {
+    const result = await executeCommand('/changed', mockContext);
+
+    expect(mockContext.setGitStatusFilter).toHaveBeenCalledWith(['modified', 'added', 'deleted', 'untracked']);
+    expect(mockContext.setFilterActive).toHaveBeenCalledWith(true);
+    expect(mockContext.setFilterQuery).toHaveBeenCalledWith('/changed');
+
+    expect(result.type).toBe('success');
+    expect(result.message).toContain('changed');
+    expect(result.message).toContain('5 found');
+  });
+
+  it('uses alias /ch correctly', async () => {
+    const result = await executeCommand('/ch', mockContext);
+
+    expect(mockContext.setGitStatusFilter).toHaveBeenCalledWith(['modified', 'added', 'deleted', 'untracked']);
+    expect(result.type).toBe('success');
+  });
+
+  it('returns error when git is disabled', async () => {
+    mockContext.gitEnabled = false;
+
+    const result = await executeCommand('/changed', mockContext);
+
+    expect(result.type).toBe('error');
+    expect(result.message).toContain('Git is not enabled');
+    expect(mockContext.setGitStatusFilter).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 found for empty tree', async () => {
+    mockContext.fileTree = [];
+
+    const result = await executeCommand('/changed', mockContext);
+
+    expect(result.type).toBe('success');
+    expect(result.message).toContain('0 found');
+  });
+
+  it('handles clean tree (all files clean)', async () => {
+    mockContext.fileTree = [
+      createFile('file1.ts', '/file1.ts'), // clean
+      createFile('file2.ts', '/file2.ts'), // clean
+    ];
+
+    const result = await executeCommand('/changed', mockContext);
+
+    expect(mockContext.setGitStatusFilter).toHaveBeenCalled();
+    expect(result.message).toContain('0 found');
+  });
+});
+
+describe('unknown commands', () => {
+  let mockContext: CommandContext;
+
+  beforeEach(() => {
+    mockContext = {
+      fileTree: [],
+      gitStatus: new Map(),
+      gitEnabled: true,
+      setGitStatusFilter: vi.fn(),
+      setFilterActive: vi.fn(),
+      setFilterQuery: vi.fn(),
+      setNotification: vi.fn(),
+      commandHistory: [],
+    };
+  });
+
+  it('returns error for unknown command', async () => {
+    const result = await executeCommand('/unknown', mockContext);
+
+    expect(result.type).toBe('error');
+    expect(result.message).toContain('Unknown command');
+  });
+
+  it('returns helpful message with /help suggestion', async () => {
+    const result = await executeCommand('/notacommand', mockContext);
+
+    expect(result.type).toBe('error');
+    expect(result.message).toContain('help');
+  });
+});
+
+describe('error handling', () => {
+  let mockContext: CommandContext;
+
+  beforeEach(() => {
+    mockContext = {
+      fileTree: [],
+      gitStatus: new Map(),
+      gitEnabled: true,
+      setGitStatusFilter: vi.fn(),
+      setFilterActive: vi.fn(),
+      setFilterQuery: vi.fn(),
+      setNotification: vi.fn(),
+      commandHistory: [],
+    };
+  });
+
+  it('gracefully handles malformed input', async () => {
+    const result = await executeCommand('not a command', mockContext);
+
+    expect(result.type).toBe('error');
+  });
+
+  it('preserves filter state on error', async () => {
+    const result = await executeCommand('/git invalid', mockContext);
+
+    expect(result.type).toBe('error');
+    expect(mockContext.setFilterActive).not.toHaveBeenCalled();
+    expect(mockContext.setGitStatusFilter).not.toHaveBeenCalled();
+  });
+});
+
+describe('filter state updates', () => {
+  let mockContext: CommandContext;
+  let sampleTree: TreeNode[];
+
+  beforeEach(() => {
+    sampleTree = [
+      createFile('modified.ts', '/modified.ts', 'modified'),
+      createFile('clean.ts', '/clean.ts'),
+    ];
+
+    mockContext = {
+      fileTree: sampleTree,
+      gitStatus: new Map([['/modified.ts', 'modified']]),
+      gitEnabled: true,
+      setGitStatusFilter: vi.fn(),
+      setFilterActive: vi.fn(),
+      setFilterQuery: vi.fn(),
+      setNotification: vi.fn(),
+      commandHistory: [],
+    };
+  });
+
+  it('updates filter state on successful command', async () => {
+    await executeCommand('/git modified', mockContext);
+
+    expect(mockContext.setFilterActive).toHaveBeenCalledWith(true);
+    expect(mockContext.setFilterQuery).toHaveBeenCalledWith('/git: modified');
+  });
+
+  it('provides correct query string format', async () => {
+    await executeCommand('/git added', mockContext);
+
+    const calls = (mockContext.setFilterQuery as any).mock.calls;
+    expect(calls[0][0]).toBe('/git: added');
+  });
+
+  it('changed command sets /changed query string', async () => {
+    await executeCommand('/changed', mockContext);
+
+    const calls = (mockContext.setFilterQuery as any).mock.calls;
+    expect(calls[0][0]).toBe('/changed');
+  });
+});
+
+describe('file tree preservation', () => {
+  it('preserves folder hierarchy when filtering', async () => {
+    const sampleTree: TreeNode[] = [
+      createFolder('src', '/src', [
+        createFolder('components', '/src/components', [
+          createFile('Button.tsx', '/src/components/Button.tsx', 'modified'),
+          createFile('Input.tsx', '/src/components/Input.tsx'),
+        ]),
+        createFile('App.tsx', '/src/App.tsx'),
+      ]),
+    ];
+
+    const mockContext: CommandContext = {
+      fileTree: sampleTree,
+      gitStatus: new Map([['/src/components/Button.tsx', 'modified']]),
+      gitEnabled: true,
+      setGitStatusFilter: vi.fn(),
+      setFilterActive: vi.fn(),
+      setFilterQuery: vi.fn(),
+      setNotification: vi.fn(),
+      commandHistory: [],
+    };
+
+    await executeCommand('/git modified', mockContext);
+
+    expect(mockContext.setGitStatusFilter).toHaveBeenCalledWith('modified');
+  });
+});


### PR DESCRIPTION
## Summary

Implements `/git [status]` and `/changed` slash commands for filtering the file tree by git status. This provides keyboard-driven git-aware navigation for developers working with AI agents, allowing quick focus on files with specific git statuses.

Closes #26

## Changes Made

- Add CommandContext interface for parser integration
- Implement command parser with /git and /changed commands
- Extend filter to support multiple git statuses
- Integrate git status filter in useFileTree hook
- Add state management in App.tsx for git filtering
- Add comprehensive test suite (34 tests)

## Implementation Notes

**Context & rationale:**
- Implements `/git [status]` and `/changed` slash commands for filtering the file tree by git status
- Integrates with existing command parser infrastructure (#22) and git status filtering (#6)
- Provides keyboard-driven git-aware navigation for developers working with AI agents
- Commands filter tree to show only files with specific git statuses while preserving folder hierarchy

**Implementation details:**
- Extended `filterTreeByGitStatus()` in filter.ts to support both single status and array of statuses for `/changed` command
- Created new `src/utils/commandParser.ts` module with:
  - CommandParser class for managing command registration and execution
  - `/git [status]` command handler for filtering by individual git statuses
  - `/changed` command handler as shorthand for all non-clean files (modified, added, deleted, untracked)
  - Proper error handling for missing git, invalid arguments, and disabled git mode
  - Alias support: `/g` for `/git`, `/ch` for `/changed`
- Extended `UseFileTreeOptions` in useFileTree hook with `gitStatusFilter` parameter
- Updated filteredTree memoization to apply git status filter before name filter
- Integrated parser into App.tsx with state management for:
  - filterActive: track whether filter is currently active
  - filterQuery: display string for active filter (e.g., "/git: modified")
  - gitStatusFilter: current git status filter(s) being applied
  - commandHistory: list of executed commands
  - Command execution handler that updates filter state and shows notifications

## Follow-up Tasks

- Future: Integration with actual git status hook when it's implemented
- Future: Command bar UI to actually accept slash commands from user input