### PR TITLE
Implement command parser and execution system

### DIFF
--- a/src/utils/commandParser.ts
+++ b/src/utils/commandParser.ts
@@ -154,6 +154,18 @@ function validateCommand(command: Command): void {
   if (typeof command.execute !== 'function') {
     throw new Error(`Command ${command.name} must have an execute function`);
   }
+
+  // Validate aliases
+  if (command.aliases) {
+    for (const alias of command.aliases) {
+      if (!alias.startsWith('/')) {
+        throw new Error(`Alias must start with /: ${alias} (in command ${command.name})`);
+      }
+      if (alias.includes(' ')) {
+        throw new Error(`Alias cannot contain spaces: ${alias} (in command ${command.name})`);
+      }
+    }
+  }
 }
 
 /**
@@ -360,7 +372,8 @@ export async function executeCommand(
       // Free text → treat as filter (default behavior)
       const filterCommand = findCommand('/filter', registry);
       if (filterCommand) {
-        return await filterCommand.execute([input], context);
+        // Use trimmed input for consistency with explicit /filter command
+        return await filterCommand.execute([parsed.args[0]], context);
       } else {
         return {
           success: false,


### PR DESCRIPTION
## Summary

Implements extensible command parser and execution system with registry-based architecture for slash commands (`/filter`, `/git`, `/wt`, `/open`, `/copytree`, etc.). Supports command aliases and free text defaulting to `/filter` for improved UX.

Closes #22

## Changes Made

- Add alias validation to ensure aliases start with / and have no spaces
- Fix free-text filter fallback to use trimmed input for consistency
- Add test for multi-argument command parsing
- Add tests for alias validation (invalid format, spaces)
- Add test for whitespace-only input handling
- Add test for free-text fallback when /filter missing from registry
- Add comprehensive /copytree command tests
- Enhance /wt worktree name test with complete assertions

## Implementation Notes

**Context & Rationale:**
- Yellowwood uses a slash command system (like Slack/Discord/Obsidian) for textual control of the file tree
- Implemented extensible command registry pattern to allow future command additions without modifying parser
- Free text input (without `/`) defaults to `/filter` for improved UX - users can type "component" instead of "/filter component"
- Command system is foundational infrastructure - actual filter/git/worktree implementations will be added in separate issues

**Implementation Details:**
- Created `src/utils/commandParser.ts` with complete command parsing and execution system
- Implemented 6 built-in commands with stub implementations:
  - `/filter` (alias `/f`) - Filter files by name pattern (stub, implementation in issue #25)
  - `/git` (alias `/g`) - Filter by git status (stub, implementation in issue #26)
  - `/changed` (alias `/c`) - Show all changed files (stub, implementation in issue #26)
  - `/wt` (alias `/worktree`) - Worktree operations (stub, implementation in issue #29)
  - `/open` (alias `/o`) - Open specific file (simple implementation provided)
  - `/copytree` (alias `/ct`) - CopyTree integration (Phase 2+, stub for now)
- Wrote comprehensive test suite with 67 test cases covering:
  - Command parsing (explicit commands, free text, edge cases)
  - Command registry (find, register, validation, alias conflicts)
  - Command execution (success/failure, error handling)
  - All built-in commands with various inputs
- All tests pass successfully

**Code Quality Improvements (from Codex review):**
- Fixed free-text filter fallback to use trimmed input instead of raw input for consistency
- Added alias validation - aliases must start with `/` and cannot contain spaces, catching configuration errors early
- Improved test coverage from 60 to 67 test cases:
  - Multi-argument parsing verification
  - Alias validation (invalid format, spaces)
  - Whitespace-only input handling
  - Free-text fallback when `/filter` missing from registry
  - Complete `/copytree` command testing
  - Enhanced `/wt` worktree name test with full assertions

## Follow-up Tasks

- Issue #25 will implement actual `/filter` command logic with fuzzy matching
- Issue #26 will implement git filter commands (`/git`, `/changed`)
- Issue #29 will implement worktree switching (`/wt`)
- Future: Consider adding command help system (e.g., `/help` or `/?`) to list all commands and their usage

## Known Limitations

Quote handling: `parseCommand` splits on whitespace without honoring quotes. Multi-word arguments (e.g., worktree names with spaces) must be handled by individual command implementations. This is acceptable for current use cases but could be enhanced in the future if needed.