### PR TITLE
Implement CLI argument parsing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,8 +1,253 @@
 #!/usr/bin/env node
 import React from 'react';
 import { render } from 'ink';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
 import App from './App.js';
+import { loadConfig } from './utils/config.js';
+import type { YellowwoodConfig } from './types/index.js';
 
-const cwd = process.argv[2] || process.cwd();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
-render(React.createElement(App, { cwd }));
+interface ParsedArgs {
+  cwd: string;
+  configOverrides: Partial<YellowwoodConfig>;
+  showHelp: boolean;
+  showVersion: boolean;
+  noWatch: boolean;
+  noGit: boolean;
+  initialFilter?: string;
+}
+
+/**
+ * Parse command-line arguments.
+ * Supports positional directory argument and various flags.
+ */
+function parseCliArgs(argv: string[]): ParsedArgs {
+  const args = argv.slice(2); // Skip 'node' and script path
+
+  const result: ParsedArgs = {
+    cwd: process.cwd(),
+    configOverrides: {},
+    showHelp: false,
+    showVersion: false,
+    noWatch: false,
+    noGit: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    // Help flags
+    if (arg === '--help' || arg === '-h') {
+      result.showHelp = true;
+      continue;
+    }
+
+    // Version flags
+    if (arg === '--version' || arg === '-v') {
+      result.showVersion = true;
+      continue;
+    }
+
+    // Boolean flags (no value)
+    if (arg === '--no-watch') {
+      result.noWatch = true;
+      result.configOverrides.autoRefresh = false;
+      continue;
+    }
+
+    if (arg === '--no-git') {
+      result.noGit = true;
+      result.configOverrides.showGitStatus = false;
+      continue;
+    }
+
+    if (arg === '--hidden' || arg === '-H') {
+      result.configOverrides.showHidden = true;
+      continue;
+    }
+
+    if (arg === '--git' || arg === '-g') {
+      result.noGit = false; // Allow --git to override --no-git
+      result.configOverrides.showGitStatus = true;
+      continue;
+    }
+
+    // Value flags (require next argument)
+    if (arg === '--editor' || arg === '-e') {
+      const editor = args[++i];
+      if (!editor || editor.startsWith('-')) {
+        throw new Error(`--editor requires a value`);
+      }
+      result.configOverrides.editor = editor;
+      continue;
+    }
+
+    if (arg === '--filter' || arg === '-f') {
+      const filter = args[++i];
+      if (!filter || filter.startsWith('-')) {
+        throw new Error(`--filter requires a value`);
+      }
+      // Store filter for later use (will be passed to App)
+      result.initialFilter = filter;
+      continue;
+    }
+
+    if (arg === '--max-depth' || arg === '-d') {
+      const depth = args[++i];
+      if (!depth) {
+        throw new Error(`--max-depth requires a number`);
+      }
+      const maxDepth = parseInt(depth, 10);
+      if (isNaN(maxDepth) || maxDepth < 0) {
+        throw new Error(`--max-depth must be a non-negative number`);
+      }
+      result.configOverrides.maxDepth = maxDepth;
+      continue;
+    }
+
+    if (arg === '--config' || arg === '-c') {
+      const configPath = args[++i];
+      if (!configPath || configPath.startsWith('-')) {
+        throw new Error(`--config requires a path`);
+      }
+      // Config path override (not implemented yet - future enhancement)
+      // Will be used by loadConfig in future
+      continue;
+    }
+
+    // Positional argument (directory path)
+    if (!arg.startsWith('-')) {
+      result.cwd = arg;
+      continue;
+    }
+
+    // Unknown flag
+    throw new Error(`Unknown flag: ${arg}\nRun 'yellowwood --help' for usage information.`);
+  }
+
+  return result;
+}
+
+/**
+ * Display help information.
+ */
+function showHelp(): void {
+  const helpText = `
+Yellowwood - Terminal-based file browser for developers
+
+USAGE
+  yellowwood [path] [options]
+
+ARGUMENTS
+  [path]                    Directory to browse (default: current directory)
+
+OPTIONS
+  -e, --editor <cmd>        Editor command (default: code)
+  -f, --filter <pattern>    Initial filter pattern
+  -d, --max-depth <n>       Maximum tree depth (default: unlimited)
+  -c, --config <path>       Path to config file
+  -g, --git                 Enable git status (default: true)
+  -H, --hidden              Show hidden files (default: false)
+  --no-watch                Disable file watching
+  --no-git                  Disable git integration
+  -h, --help                Show this help message
+  -v, --version             Show version number
+
+EXAMPLES
+  yellowwood                                    # Browse current directory
+  yellowwood /path/to/project                   # Browse specific directory
+  yellowwood --filter .ts                       # Start with .ts files filtered
+  yellowwood --editor vim --no-watch            # Use vim, disable watching
+  yellowwood ~/project --max-depth 3 --hidden   # Limit depth, show hidden
+
+KEYBOARD SHORTCUTS
+  ↑/↓         Navigate tree
+  ←/→         Collapse/expand folders
+  Enter       Open file or toggle folder
+  Space       Toggle folder expansion
+  /           Open command bar
+  g           Toggle git status visibility
+  w           Switch worktree
+  c           Copy path or CopyTree reference
+  r           Manual refresh
+  ?           Show help
+  q           Quit
+
+CONFIGURATION
+  Project:  .yellowwood.json
+  Global:   ~/.config/yellowwood/config.json
+
+For more information, visit: https://github.com/gregpriday/yellowwood
+`;
+
+  console.log(helpText);
+}
+
+/**
+ * Display version information.
+ */
+function showVersion(): void {
+  try {
+    const packageJsonPath = join(__dirname, '../package.json');
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+    console.log(`yellowwood v${packageJson.version}`);
+  } catch (error) {
+    console.log('yellowwood v?.?.? (version not found)');
+  }
+}
+
+/**
+ * Main CLI entry point.
+ */
+async function main(): Promise<void> {
+  try {
+    // Parse command-line arguments
+    const parsedArgs = parseCliArgs(process.argv);
+
+    // Handle help and version flags (exit after showing)
+    if (parsedArgs.showHelp) {
+      showHelp();
+      process.exit(0);
+    }
+
+    if (parsedArgs.showVersion) {
+      showVersion();
+      process.exit(0);
+    }
+
+    // Load configuration from files
+    const baseConfig = await loadConfig(parsedArgs.cwd);
+
+    // Merge CLI overrides with loaded config
+    // CLI overrides have highest precedence
+    const finalConfig: YellowwoodConfig = {
+      ...baseConfig,
+      ...parsedArgs.configOverrides,
+    };
+
+    // Render the Ink app
+    render(
+      React.createElement(App, {
+        cwd: parsedArgs.cwd,
+        config: finalConfig,
+        noWatch: parsedArgs.noWatch,
+        noGit: parsedArgs.noGit,
+        initialFilter: parsedArgs.initialFilter,
+      })
+    );
+  } catch (error) {
+    // Handle CLI parsing errors
+    if (error instanceof Error) {
+      console.error(`Error: ${error.message}`);
+      process.exit(1);
+    }
+    throw error;
+  }
+}
+
+// Run the CLI
+main();

--- a/tests/cli/cli_args.test.ts
+++ b/tests/cli/cli_args.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Path to compiled CLI script
+const cliPath = path.join(__dirname, '../../dist/cli.js');
+
+/**
+ * Helper to run CLI with args and capture output.
+ */
+async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return new Promise((resolve) => {
+    const child = spawn('node', [cliPath, ...args], {
+      env: { ...process.env, FORCE_COLOR: '0' }, // Disable colors for testing
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    child.on('close', (exitCode) => {
+      resolve({ stdout, stderr, exitCode: exitCode || 0 });
+    });
+
+    // Kill after 2 seconds to avoid hanging
+    setTimeout(() => {
+      child.kill();
+      resolve({ stdout, stderr, exitCode: -1 });
+    }, 2000);
+  });
+}
+
+describe('CLI argument parsing', () => {
+  it('shows help with --help flag', async () => {
+    const { stdout, exitCode } = await runCli(['--help']);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('Yellowwood');
+    expect(stdout).toContain('USAGE');
+    expect(stdout).toContain('OPTIONS');
+    expect(stdout).toContain('--editor');
+    expect(stdout).toContain('--filter');
+    expect(stdout).toContain('EXAMPLES');
+  });
+
+  it('shows help with -h flag', async () => {
+    const { stdout, exitCode } = await runCli(['-h']);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('USAGE');
+    expect(stdout).toContain('yellowwood [path] [options]');
+  });
+
+  it('shows version with --version flag', async () => {
+    const { stdout, exitCode } = await runCli(['--version']);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/yellowwood v\d+\.\d+\.\d+/);
+  });
+
+  it('shows version with -v flag', async () => {
+    const { stdout, exitCode } = await runCli(['-v']);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/yellowwood v\d+\.\d+\.\d+/);
+  });
+
+  it('errors on unknown flag', async () => {
+    const { stderr, exitCode } = await runCli(['--unknown-flag']);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('Unknown flag');
+    expect(stderr).toContain('--unknown-flag');
+    expect(stderr).toContain('--help');
+  });
+
+  it('errors when --editor has no value', async () => {
+    const { stderr, exitCode } = await runCli(['--editor']);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('--editor requires a value');
+  });
+
+  it('errors when --editor value starts with dash', async () => {
+    const { stderr, exitCode } = await runCli(['--editor', '--other-flag']);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('--editor requires a value');
+  });
+
+  it('errors when --filter has no value', async () => {
+    const { stderr, exitCode } = await runCli(['--filter']);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('--filter requires a value');
+  });
+
+  it('errors when --max-depth has no value', async () => {
+    const { stderr, exitCode } = await runCli(['--max-depth']);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('--max-depth requires a number');
+  });
+
+  it('errors when --max-depth has invalid value', async () => {
+    const { stderr, exitCode } = await runCli(['--max-depth', 'abc']);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('--max-depth must be a non-negative number');
+  });
+
+  it('errors when --max-depth is negative', async () => {
+    const { stderr, exitCode } = await runCli(['--max-depth', '-5']);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('--max-depth must be a non-negative number');
+  });
+
+  it('errors when --config has no value', async () => {
+    const { stderr, exitCode } = await runCli(['--config']);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('--config requires a path');
+  });
+
+  it('accepts short alias -e for --editor', async () => {
+    const { stderr, exitCode } = await runCli(['-e']);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('--editor requires a value');
+  });
+
+  it('accepts short alias -f for --filter', async () => {
+    const { stderr, exitCode } = await runCli(['-f']);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('--filter requires a value');
+  });
+
+  it('accepts short alias -d for --max-depth', async () => {
+    const { stderr, exitCode } = await runCli(['-d']);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('--max-depth requires a number');
+  });
+
+  it('accepts short alias -c for --config', async () => {
+    const { stderr, exitCode } = await runCli(['-c']);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('--config requires a path');
+  });
+});
+
+describe('CLI flag behavior', () => {
+  it('accepts valid --max-depth value', async () => {
+    // This would normally start the app, so we just check it doesn't error immediately
+    const { stderr, exitCode } = await runCli(['--max-depth', '5']);
+
+    // Should either start app (exit -1 due to kill) or succeed
+    // Should NOT have a parse error
+    expect(stderr).not.toContain('--max-depth must be a non-negative number');
+  });
+
+  it('accepts zero as valid --max-depth', async () => {
+    const { stderr } = await runCli(['--max-depth', '0']);
+
+    // Should not have a parse error
+    expect(stderr).not.toContain('--max-depth must be a non-negative number');
+  });
+
+  it('accepts directory as positional argument', async () => {
+    const { stderr } = await runCli(['/tmp']);
+
+    // Should not error on the directory argument
+    expect(stderr).not.toContain('Unknown flag');
+  });
+
+  it('accepts directory with flags', async () => {
+    const { stderr } = await runCli(['/tmp', '--hidden']);
+
+    // Should not error on either argument
+    expect(stderr).not.toContain('Unknown flag');
+  });
+
+  it('accepts flags before directory', async () => {
+    const { stderr } = await runCli(['--hidden', '/tmp']);
+
+    // Should not error - order shouldn't matter
+    expect(stderr).not.toContain('Unknown flag');
+  });
+});


### PR DESCRIPTION
## Summary

Implements comprehensive CLI argument parsing to accept directory paths and command-line flags that override configuration settings. Users can now pass flags like `--editor`, `--filter`, `--max-depth`, `--no-watch`, `--no-git`, and `--help` to control Yellowwood's behavior without modifying config files.

Closes #35

## Changes Made

- Add parseCliArgs() function supporting all flags from SPEC.md §7
- Support boolean flags: --no-watch, --no-git, --hidden, --git
- Support value flags: --editor, --filter, --max-depth, --config
- Implement short aliases: -e, -f, -d, -h, -v, -H, -g, -c
- Add --help and --version commands with formatted output
- Extend App.tsx to accept config, noWatch, noGit, initialFilter props
- Update switchWorktree to apply initial filter and respect noWatch
- Add createNullWatcher for --no-watch functionality
- Implement config override precedence (CLI > project > global > defaults)
- Add 21 comprehensive tests covering all flags and error cases
- Allow --git to override earlier --no-git (last flag wins)

## Implementation Notes

**Context & rationale:**
- Previously, `src/cli.ts` only accepted a single directory argument with no flag parsing
- Users couldn't override config settings from command line, making quick experiments difficult
- No `--help` or `--version` support for discoverability
- Implemented manual parsing (no external library) to keep bundle small and maintain full control

**Implementation details:**
- **CLI parsing**: Manual parsing in `parseCliArgs()` function supports all flags from SPEC.md §7
- **Supported flags**: `--editor`, `--filter`, `--max-depth`, `--no-watch`, `--no-git`, `--hidden`, `--git`, `--help`, `--version`
- **Short aliases**: `-e`, `-f`, `-d`, `-h`, `-v`, `-H`, `-g`, `-c`
- **Config precedence**: CLI flags > project config > global config > defaults
- **Help/Version**: Early exit before rendering App when `--help` or `--version` specified
- **App.tsx props**: Extended to accept `config`, `noWatch`, `noGit`, and `initialFilter` from CLI
- **Error handling**: Clear error messages for invalid flags, missing values, and invalid values
- **Testing**: 21 comprehensive tests covering all flags, aliases, error cases, and edge cases
- **Filter support**: `--filter` pattern is applied during worktree initialization via `switchWorktree`
- **Watch control**: `--no-watch` prevents file watcher creation by using a no-op watcher
- **Flag precedence**: `--git` can override earlier `--no-git` (last flag wins)

## Breaking Changes & Migration Hints

**Breaking changes:** None - backward compatible. Existing `yellowwood /path` usage still works

**Migration hints:** N/A - fully backward compatible

## Follow-up Tasks

- Future: Support `--config <path>` to override config file location (parsing logic ready, loadConfig needs update)
- Future: Add more flags as needed (--theme, --sort, etc.)
- Future: Consider shell completion scripts (bash, zsh, fish)