### PR TITLE
Wire all keyboard shortcuts

### DIFF
--- a/src/components/TreeView.tsx
+++ b/src/components/TreeView.tsx
@@ -1,16 +1,16 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import { Box, Text, useStdout } from 'ink';
+import { Box, Text } from 'ink';
 import type { TreeNode, YellowwoodConfig } from '../types/index.js';
 import { TreeNode as TreeNodeComponent } from './TreeNode.js';
 import {
   flattenVisibleTree,
   calculateVisibleWindow,
-  calculateViewportHeight,
   findNodeIndex,
   calculateScrollToNode,
 } from '../utils/treeViewVirtualization.js';
 import { useKeyboard } from '../hooks/useKeyboard.js';
 import { useMouse } from '../hooks/useMouse.js';
+import { useViewportHeight } from '../hooks/useViewportHeight.js';
 import type { FlattenedNode } from '../utils/treeViewVirtualization.js';
 
 interface TreeViewProps {
@@ -32,30 +32,16 @@ export const TreeView: React.FC<TreeViewProps> = ({
   onToggleExpand,
   disableKeyboard = false,
 }) => {
-  const { stdout } = useStdout();
+  // Viewport height from shared hook
+  const viewportHeight = useViewportHeight();
 
-  // Viewport state
-  const [viewportHeight, setViewportHeight] = useState(() => calculateViewportHeight());
+  // Scroll state
   const [scrollOffset, setScrollOffset] = useState(0);
 
   // Track expanded folders (use controlled if provided, otherwise internal state)
   const [internalExpandedPaths, setInternalExpandedPaths] = useState<Set<string>>(new Set());
   const isControlledExpansion = controlledExpandedPaths != null && onToggleExpand != null;
   const expandedPaths = isControlledExpansion ? controlledExpandedPaths : internalExpandedPaths;
-
-  // Update viewport height on terminal resize
-  useEffect(() => {
-    const handleResize = () => {
-      setViewportHeight(calculateViewportHeight());
-    };
-
-    if (stdout) {
-      stdout.on('resize', handleResize);
-      return () => {
-        stdout.off('resize', handleResize);
-      };
-    }
-  }, [stdout]);
 
   // Flatten the tree (memoized - only recalculate when tree structure or expansion changes)
   const flattenedTree = useMemo<FlattenedNode[]>(() => {

--- a/src/hooks/useViewportHeight.ts
+++ b/src/hooks/useViewportHeight.ts
@@ -1,0 +1,40 @@
+import { useState, useEffect } from 'react';
+import { useStdout } from 'ink';
+import { calculateViewportHeight } from '../utils/treeViewVirtualization.js';
+
+/**
+ * Custom hook for tracking viewport height with terminal resize support.
+ *
+ * Encapsulates stdout resize measurements for reuse by App and TreeView.
+ * Ensures both use the same reserved-row calculation for consistent behavior.
+ *
+ * @param reservedRows - Number of rows reserved for header/status bar (default: 3)
+ * @returns Current viewport height in rows
+ *
+ * @example
+ * ```typescript
+ * const viewportHeight = useViewportHeight();
+ * // Returns available height for tree content, auto-updates on terminal resize
+ * ```
+ */
+export function useViewportHeight(reservedRows = 3): number {
+  const { stdout } = useStdout();
+  const [viewportHeight, setViewportHeight] = useState(() =>
+    calculateViewportHeight(reservedRows)
+  );
+
+  useEffect(() => {
+    const handleResize = () => {
+      setViewportHeight(calculateViewportHeight(reservedRows));
+    };
+
+    if (stdout) {
+      stdout.on('resize', handleResize);
+      return () => {
+        stdout.off('resize', handleResize);
+      };
+    }
+  }, [stdout, reservedRows]);
+
+  return viewportHeight;
+}

--- a/src/utils/treeNavigation.ts
+++ b/src/utils/treeNavigation.ts
@@ -1,0 +1,173 @@
+import path from 'path';
+import type { TreeNode } from '../types/index.js';
+import { flattenVisibleTree, findNodeIndex, type FlattenedNode } from './treeViewVirtualization.js';
+
+/**
+ * Navigation helpers for tree operations.
+ * These utilities provide the core navigation logic used by both TreeView and App.
+ */
+
+/**
+ * Move selection up by delta rows.
+ *
+ * @param flattenedTree - Flattened tree nodes
+ * @param currentPath - Currently selected path
+ * @param delta - Number of rows to move (positive = down, negative = up)
+ * @returns New selected path, or current path if movement not possible
+ */
+export function moveSelection(
+  flattenedTree: FlattenedNode[],
+  currentPath: string,
+  delta: number
+): string {
+  const currentIndex = findNodeIndex(flattenedTree, currentPath);
+  if (currentIndex < 0) {
+    // Current path not found, select first node
+    return flattenedTree[0]?.path || currentPath;
+  }
+
+  const newIndex = Math.max(0, Math.min(flattenedTree.length - 1, currentIndex + delta));
+  return flattenedTree[newIndex]?.path || currentPath;
+}
+
+/**
+ * Jump to start of tree.
+ *
+ * @param flattenedTree - Flattened tree nodes
+ * @returns Path of first node, or empty string if tree is empty
+ */
+export function jumpToStart(flattenedTree: FlattenedNode[]): string {
+  return flattenedTree[0]?.path || '';
+}
+
+/**
+ * Jump to end of tree.
+ *
+ * @param flattenedTree - Flattened tree nodes
+ * @returns Path of last node, or empty string if tree is empty
+ */
+export function jumpToEnd(flattenedTree: FlattenedNode[]): string {
+  const lastIndex = flattenedTree.length - 1;
+  return flattenedTree[lastIndex]?.path || '';
+}
+
+/**
+ * Get the currently selected node.
+ *
+ * @param flattenedTree - Flattened tree nodes
+ * @param currentPath - Currently selected path
+ * @returns Selected node, or null if not found
+ */
+export function getCurrentNode(
+  flattenedTree: FlattenedNode[],
+  currentPath: string
+): FlattenedNode | null {
+  const index = findNodeIndex(flattenedTree, currentPath);
+  return index >= 0 ? flattenedTree[index] : null;
+}
+
+/**
+ * Determine action for right arrow key: expand folder if collapsed, or open if already expanded.
+ *
+ * @param node - Current node
+ * @param expandedPaths - Set of expanded folder paths
+ * @returns Action to take: 'expand' | 'open' | 'none'
+ */
+export function getRightArrowAction(
+  node: FlattenedNode | null,
+  expandedPaths: Set<string>
+): 'expand' | 'open' | 'none' {
+  if (!node) return 'none';
+
+  if (node.type === 'directory') {
+    // If directory is not expanded, expand it
+    if (!expandedPaths.has(node.path)) {
+      return 'expand';
+    }
+    // If directory is expanded but has no children, do nothing
+    if (!node.children || node.children.length === 0) {
+      return 'none';
+    }
+    // If directory is expanded and has children, move to first child (handled by navigation)
+    return 'none';
+  }
+
+  // For files, right arrow opens the file
+  return 'open';
+}
+
+/**
+ * Determine action for left arrow key: collapse folder if expanded, or move to parent.
+ *
+ * @param node - Current node
+ * @param flattenedTree - Flattened tree nodes
+ * @param expandedPaths - Set of expanded folder paths
+ * @returns Action object with type and optional target path
+ */
+export function getLeftArrowAction(
+  node: FlattenedNode | null,
+  flattenedTree: FlattenedNode[],
+  expandedPaths: Set<string>
+): { type: 'collapse' | 'parent' | 'none'; path?: string } {
+  if (!node) return { type: 'none' };
+
+  // If current node is an expanded directory, collapse it
+  if (node.type === 'directory' && expandedPaths.has(node.path)) {
+    return { type: 'collapse', path: node.path };
+  }
+
+  // Otherwise, move to parent
+  const parentPath = getParentPath(node.path);
+  if (!parentPath) {
+    return { type: 'none' };
+  }
+
+  // Find parent in flattened tree
+  const parentIndex = findNodeIndex(flattenedTree, parentPath);
+  if (parentIndex >= 0) {
+    return { type: 'parent', path: parentPath };
+  }
+
+  return { type: 'none' };
+}
+
+/**
+ * Get parent path from a file/folder path.
+ *
+ * @param path - File or folder path
+ * @returns Parent directory path, or null if at root
+ */
+export function getParentPath(filePath: string): string | null {
+  const normalized = path.normalize(filePath);
+  const parentPath = path.dirname(normalized);
+
+  if (!parentPath || parentPath === '.' || parentPath === normalized) {
+    return null;
+  }
+
+  return parentPath;
+}
+
+/**
+ * Create flattened tree with expansion state applied.
+ *
+ * @param fileTree - Original file tree
+ * @param expandedPaths - Set of expanded folder paths
+ * @returns Flattened tree with correct expansion state
+ */
+export function createFlattenedTree(
+  fileTree: TreeNode[],
+  expandedPaths: Set<string>
+): FlattenedNode[] {
+  // Mark nodes as expanded based on expansion state
+  const markExpanded = (nodes: TreeNode[]): TreeNode[] => {
+    return nodes.map((node) => ({
+      ...node,
+      expanded: expandedPaths.has(node.path) || node.expanded || false,
+      children: node.children ? markExpanded(node.children) : undefined,
+    }));
+  };
+
+  const markedTree = markExpanded(fileTree);
+  return flattenVisibleTree(markedTree);
+}


### PR DESCRIPTION
## Summary

Implements comprehensive keyboard shortcuts for Yellowwood's keyboard-first file browser interface, wiring all shortcuts defined in SPEC.md §5.5 to their respective actions in App.tsx.

Closes #39

## Changes Made

- Add useViewportHeight hook for shared viewport measurement between App and TreeView
- Create treeNavigation utilities with moveSelection, jumpToStart/End, arrow key actions
- Wire all keyboard shortcuts in App.tsx (navigation, git toggle, help, filter, quit)
- Add modal state management (showHelpModal, showGitMarkers) with proper gating
- Implement all missing handlers: navigate up/down/left/right, page up/down, home/end, git toggle, help modal, filter prefill, quit
- Update TreeView to use shared useViewportHeight hook
- Add HelpModal rendering controlled by state
- Fix React hooks order violation by placing effectiveConfig useMemo before conditional returns

## Implementation Notes

**Context & rationale:**
- Yellowwood is designed as a keyboard-first file browser - this PR implements all keyboard shortcuts defined in SPEC.md §5.5
- Previously only a handful of shortcuts were wired (command bar, worktree cycling, file operations)
- Now all navigation, git toggles, help modal, filter prefill, and quit functionality are fully implemented
- Used Codex MCP for implementation planning and guidance throughout development

**Implementation details:**
- Created `useViewportHeight` hook to share viewport measurement between App and TreeView
- Created `utils/treeNavigation.ts` with shared navigation logic for keyboard operations
- Added new state to App.tsx:
  - `showHelpModal` - controls help overlay visibility
  - `showGitMarkers` - separate git marker visibility from git fetching (allows toggle without performance cost)
  - `viewportHeight` - shared viewport height for page up/down calculations
  - `flattenedTree` - memoized flattened tree for navigation
- Implemented all missing keyboard handlers:
  - Navigation: up/down/left/right arrows, page up/down, home/end
  - Git: `g` toggles marker visibility
  - Help: `?` toggles help modal
  - Filter: `Ctrl+F` opens command bar with `/filter ` prefilled
  - Quit: `q` stops watchers and exits cleanly
  - CopyTree: `C` shows "coming soon" notification (placeholder for Phase 2)
- Updated `handleClearFilter` to close modals in priority order: help → context menu → worktree panel → command bar → filter
- Added modal gating: keyboard shortcuts disabled when any modal/overlay is open (except ESC, quit, and help toggle)
- Updated TreeView to use shared `useViewportHeight` hook for consistency
- Wired HelpModal component rendering with visibility controlled by state

## Breaking Changes & Migration Hints

- None - this is additive functionality only
- All existing keyboard shortcuts continue to work as before
- No migration needed - all changes are backwards compatible

## Follow-up Tasks

- Consider making keyboard shortcuts configurable in future (user-defined keybindings)