### PR TITLE
Fix: Validate selection state after file deletion

### DIFF
--- a/src/utils/treeNavigation.ts
+++ b/src/utils/treeNavigation.ts
@@ -171,3 +171,24 @@ export function createFlattenedTree(
   const markedTree = markExpanded(fileTree);
   return flattenVisibleTree(markedTree);
 }
+
+/**
+ * Recursively search tree for a node with the given path.
+ *
+ * @param tree - Tree nodes to search
+ * @param targetPath - Path to find
+ * @returns true if path exists in tree, false otherwise
+ */
+export function findNodeInTree(tree: TreeNode[], targetPath: string): boolean {
+  for (const node of tree) {
+    if (node.path === targetPath) {
+      return true;
+    }
+    if (node.children && node.children.length > 0) {
+      if (findNodeInTree(node.children, targetPath)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

Fixes the issue where the selection state becomes stale when files or folders are deleted externally, causing the cursor to jump to the top of the tree. Now automatically moves selection to the nearest valid alternative (parent directory → root fallback).

Closes #101

## Changes Made

- Added `findNodeInTree` helper function to recursively search tree for path existence
- Added selection validation effect in `useFileTree` that runs after tree updates
- When selected path no longer exists, automatically move to parent directory
- Fall back to `rootPath` (then `tree[0]`) if parent is also deleted
- Clear selection if tree becomes empty
- Added comprehensive tests for all deletion scenarios (8 new test cases)
- Updated existing tests to use event bus pattern (`events.emit`) instead of calling hook methods directly

## Implementation Notes

**Context & Rationale:**
- Issue: File watcher rebuilds tree but never validates if `selectedPath` still exists
- Result: `TreeView` defaults to index 0 (top of tree), causing disorienting UX
- Solution: Reactive effect validates selection after tree changes, moves to nearest valid path
- Priority: parent (maintains context) → root (safe fallback)
- Future-proofs against `ENOENT` crashes when new features use fs operations on `selectedPath`

**Implementation Details:**
- Added `findNodeInTree` helper to `src/utils/treeNavigation.ts` - recursively searches tree for path existence
- Added selection validation effect in `src/hooks/useFileTree.ts` that runs after tree updates
- Validation strategy: parent directory → root fallback (when parent also deleted)
- Effect only runs when tree loaded, not empty, and selection exists (avoids initial load race)
- Uses existing `getParentPath` utility for parent resolution
- Root fallback now checks `rootPath` exists before using it (more robust than `tree[0]`)

**Technical Notes:**
- Root fallback now checks `rootPath` exists before using it (more robust than `tree[0]`)
- Performance: `findNodeInTree` is O(n) recursive, acceptable for typical project sizes
- Effect dependency on `rootPath` is intentional - ensures validation runs when root changes

## Follow-up Tasks

- Test suite updated to use event bus pattern (`events.emit`) instead of calling hook methods directly
- All 32 tests in `useFileTree.test.ts` pass, including 8 new deletion scenario tests
- Build passes with no TypeScript errors