### PR TITLE
feat(activity): add recent activity event tracking foundation

### DIFF
--- a/src/hooks/useRecentActivity.ts
+++ b/src/hooks/useRecentActivity.ts
@@ -1,0 +1,180 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import path from 'path';
+import type { ActivityEvent, RecentActivityConfig } from '../types/index.js';
+import { events } from '../services/events.js';
+
+/**
+ * Hook return value interface
+ */
+export interface UseRecentActivityReturn {
+  /** Array of recent activity events, sorted by timestamp (newest first) */
+  recentEvents: ActivityEvent[];
+  /** Most recent event, or null if no events */
+  lastEvent: ActivityEvent | null;
+  /** Manually clear all events */
+  clearEvents: () => void;
+}
+
+/**
+ * React hook to track recent file system activity from watcher events.
+ *
+ * Features:
+ * - Subscribes to watcher:change events from the event bus
+ * - Maintains a ring buffer with time-based and size-based pruning
+ * - Deduplicates events for the same path (keeps only latest)
+ * - Converts absolute paths to workspace-relative paths
+ * - Automatically prunes events older than configured window
+ * - Respects maxEntries limit
+ *
+ * @param rootPath - Root path of the workspace (for converting absolute to relative paths)
+ * @param config - Configuration options for the recent activity feature
+ * @returns Recent activity state and control functions
+ *
+ * @example
+ * ```typescript
+ * const { recentEvents, lastEvent, clearEvents } = useRecentActivity(
+ *   '/path/to/workspace',
+ *   { enabled: true, windowMinutes: 10, maxEntries: 50 }
+ * );
+ *
+ * // Display recent events
+ * recentEvents.forEach(event => {
+ *   console.log(`${event.type}: ${event.path} at ${new Date(event.timestamp)}`);
+ * });
+ * ```
+ */
+export function useRecentActivity(
+  rootPath: string,
+  config: RecentActivityConfig
+): UseRecentActivityReturn {
+  // State: array of events, newest first
+  const [events_list, setEvents] = useState<ActivityEvent[]>([]);
+
+  // Ref to track if component is mounted (prevent setState after unmount)
+  const isMountedRef = useRef<boolean>(true);
+
+  /**
+   * Prunes events based on time window and max entries.
+   * Returns a new array with old/excess events removed.
+   */
+  const pruneEvents = useCallback(
+    (eventList: ActivityEvent[]): ActivityEvent[] => {
+      const now = Date.now();
+      const windowMs = config.windowMinutes * 60 * 1000;
+
+      // First, filter by time window
+      let pruned = eventList.filter(event => now - event.timestamp <= windowMs);
+
+      // Then, limit by max entries (keep newest)
+      if (pruned.length > config.maxEntries) {
+        pruned = pruned.slice(0, config.maxEntries);
+      }
+
+      return pruned;
+    },
+    [config.windowMinutes, config.maxEntries]
+  );
+
+  /**
+   * Handles a new watcher event by adding it to the buffer,
+   * deduplicating, and pruning as needed.
+   */
+  const handleWatcherEvent = useCallback(
+    (payload: { type: 'add' | 'change' | 'unlink' | 'addDir' | 'unlinkDir'; path: string }) => {
+      if (!config.enabled || !isMountedRef.current) {
+        return;
+      }
+
+      // Convert absolute path to relative path
+      const relativePath = path.relative(rootPath, payload.path);
+
+      // Create new event
+      const newEvent: ActivityEvent = {
+        path: relativePath,
+        type: payload.type,
+        timestamp: Date.now(),
+      };
+
+      setEvents(prevEvents => {
+        // Remove any existing events for the same path (deduplication)
+        const deduplicated = prevEvents.filter(event => event.path !== relativePath);
+
+        // Prepend new event
+        const updated = [newEvent, ...deduplicated];
+
+        // Prune old events
+        return pruneEvents(updated);
+      });
+    },
+    [rootPath, config.enabled, pruneEvents]
+  );
+
+  /**
+   * Clears all events from the buffer.
+   */
+  const clearEvents = useCallback(() => {
+    if (isMountedRef.current) {
+      setEvents([]);
+    }
+  }, []);
+
+  /**
+   * Subscribe to watcher:change events from the event bus.
+   */
+  useEffect(() => {
+    if (!config.enabled) {
+      // Clear events if feature is disabled
+      setEvents([]);
+      return;
+    }
+
+    // Subscribe to watcher events
+    const unsubscribe = events.on('watcher:change', handleWatcherEvent);
+
+    // Cleanup on unmount or config change
+    return () => {
+      unsubscribe();
+    };
+  }, [config.enabled, handleWatcherEvent]);
+
+  /**
+   * Periodically prune old events based on time window.
+   * This ensures events expire even if no new events come in.
+   */
+  useEffect(() => {
+    if (!config.enabled) {
+      return;
+    }
+
+    // Prune every minute
+    const intervalId = setInterval(() => {
+      if (isMountedRef.current) {
+        setEvents(prevEvents => pruneEvents(prevEvents));
+      }
+    }, 60 * 1000); // 1 minute
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [config.enabled, pruneEvents]);
+
+  /**
+   * Mark component as unmounted on cleanup.
+   */
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  // Calculate lastEvent (most recent)
+  const lastEvent = events_list.length > 0 ? events_list[0] : null;
+
+  return {
+    recentEvents: events_list,
+    lastEvent,
+    clearEvents,
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -63,6 +63,31 @@ export interface OpenersConfig {
   byGlob: Record<string, OpenerConfig>;
 }
 
+/**
+ * Represents a single file system activity event captured from the watcher.
+ * Paths are relative to the workspace root for consistency.
+ */
+export interface ActivityEvent {
+  /** Workspace-relative path to the file/directory */
+  path: string;
+  /** Type of file system change */
+  type: 'add' | 'change' | 'unlink' | 'addDir' | 'unlinkDir';
+  /** Unix timestamp (milliseconds) when the event occurred */
+  timestamp: number;
+}
+
+/**
+ * Configuration options for the Recent Activity feature.
+ */
+export interface RecentActivityConfig {
+  /** Whether the feature is enabled */
+  enabled: boolean;
+  /** Time window in minutes to keep events (older events are pruned) */
+  windowMinutes: number;
+  /** Maximum number of events to retain (oldest are pruned) */
+  maxEntries: number;
+}
+
 export interface CanopyConfig {
   editor: string;
   editorArgs: string[];
@@ -96,6 +121,7 @@ export interface CanopyConfig {
     showInHeader: boolean;     // Show/hide worktree indicator in header
     refreshIntervalMs?: number; // Optional: auto-refresh interval (0 = disabled)
   };
+  recentActivity?: RecentActivityConfig;
 }
 
 export interface CanopyState {
@@ -164,5 +190,10 @@ export const DEFAULT_CONFIG: CanopyConfig = {
     enable: true,              // Enabled by default for backwards compatibility
     showInHeader: true,        // Show indicator by default
     refreshIntervalMs: 10000,  // 10 second refresh by default
+  },
+  recentActivity: {
+    enabled: true,             // Enabled by default
+    windowMinutes: 10,         // Keep events from last 10 minutes
+    maxEntries: 50,            // Maximum 50 events in buffer
   },
 };

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -218,6 +218,19 @@ function mergeConfigs(...configs: Partial<CanopyConfig>[]): CanopyConfig {
         continue;
       }
 
+      if (
+        typedKey === 'recentActivity' &&
+        value &&
+        typeof value === 'object' &&
+        !Array.isArray(value)
+      ) {
+        merged[typedKey] = {
+          ...merged.recentActivity,
+          ...value,
+        } as typeof merged.recentActivity;
+        continue;
+      }
+
       (merged as any)[typedKey] = value;
     }
   }
@@ -412,6 +425,23 @@ function validateConfig(config: unknown): CanopyConfig {
         if (typeof c.worktrees.refreshIntervalMs !== 'number' || c.worktrees.refreshIntervalMs < 0) {
           errors.push('config.worktrees.refreshIntervalMs must be a non-negative number');
         }
+      }
+    }
+  }
+
+  // Validate recentActivity (optional field)
+  if (c.recentActivity !== undefined) {
+    if (!c.recentActivity || typeof c.recentActivity !== 'object') {
+      errors.push('config.recentActivity must be an object');
+    } else {
+      if (typeof c.recentActivity.enabled !== 'boolean') {
+        errors.push('config.recentActivity.enabled must be a boolean');
+      }
+      if (typeof c.recentActivity.windowMinutes !== 'number' || c.recentActivity.windowMinutes <= 0) {
+        errors.push('config.recentActivity.windowMinutes must be a positive number');
+      }
+      if (typeof c.recentActivity.maxEntries !== 'number' || c.recentActivity.maxEntries <= 0) {
+        errors.push('config.recentActivity.maxEntries must be a positive number');
       }
     }
   }

--- a/tests/hooks/useRecentActivity.test.ts
+++ b/tests/hooks/useRecentActivity.test.ts
@@ -1,0 +1,407 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useRecentActivity } from '../../src/hooks/useRecentActivity.js';
+import { events } from '../../src/services/events.js';
+import type { RecentActivityConfig } from '../../src/types/index.js';
+
+describe('useRecentActivity', () => {
+  const testRootPath = '/test/workspace';
+  const defaultConfig: RecentActivityConfig = {
+    enabled: true,
+    windowMinutes: 10,
+    maxEntries: 50,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('initializes with empty events', () => {
+    const { result } = renderHook(() => useRecentActivity(testRootPath, defaultConfig));
+
+    expect(result.current.recentEvents).toEqual([]);
+    expect(result.current.lastEvent).toBeNull();
+    expect(typeof result.current.clearEvents).toBe('function');
+  });
+
+  it('captures watcher events and converts to relative paths', () => {
+    const { result } = renderHook(() => useRecentActivity(testRootPath, defaultConfig));
+
+    // Emit a watcher event with absolute path
+    act(() => {
+      events.emit('watcher:change', {
+        type: 'change',
+        path: '/test/workspace/src/App.tsx',
+      });
+    });
+
+    expect(result.current.recentEvents).toHaveLength(1);
+
+    const event = result.current.recentEvents[0];
+    expect(event.path).toBe('src/App.tsx'); // Converted to relative
+    expect(event.type).toBe('change');
+    expect(event.timestamp).toBeGreaterThan(0);
+  });
+
+  it('stores events with newest first', () => {
+    const { result } = renderHook(() => useRecentActivity(testRootPath, defaultConfig));
+
+    // Emit multiple events
+    act(() => {
+      events.emit('watcher:change', {
+        type: 'add',
+        path: '/test/workspace/file1.txt',
+      });
+      vi.advanceTimersByTime(100);
+      events.emit('watcher:change', {
+        type: 'change',
+        path: '/test/workspace/file2.txt',
+      });
+      vi.advanceTimersByTime(100);
+      events.emit('watcher:change', {
+        type: 'unlink',
+        path: '/test/workspace/file3.txt',
+      });
+    });
+
+    expect(result.current.recentEvents).toHaveLength(3);
+
+    // Newest should be first
+    expect(result.current.recentEvents[0].path).toBe('file3.txt');
+    expect(result.current.recentEvents[1].path).toBe('file2.txt');
+    expect(result.current.recentEvents[2].path).toBe('file1.txt');
+
+    // lastEvent should be the most recent
+    expect(result.current.lastEvent?.path).toBe('file3.txt');
+  });
+
+  it('deduplicates events for the same path (keeps latest)', () => {
+    const { result } = renderHook(() => useRecentActivity(testRootPath, defaultConfig));
+
+    // Emit event for file1.txt with type 'add'
+    act(() => {
+      events.emit('watcher:change', {
+        type: 'add',
+        path: '/test/workspace/src/file1.txt',
+      });
+    });
+
+    expect(result.current.recentEvents).toHaveLength(1);
+    expect(result.current.recentEvents[0].type).toBe('add');
+
+    // Emit another event for same path with type 'change'
+    act(() => {
+      vi.advanceTimersByTime(1000);
+      events.emit('watcher:change', {
+        type: 'change',
+        path: '/test/workspace/src/file1.txt',
+      });
+    });
+
+    // Should still have only 1 event (deduplicated)
+    expect(result.current.recentEvents).toHaveLength(1);
+
+    // Should have kept the latest event
+    expect(result.current.recentEvents[0].type).toBe('change');
+    expect(result.current.recentEvents[0].path).toBe('src/file1.txt');
+  });
+
+  it('respects maxEntries limit', () => {
+    const smallConfig: RecentActivityConfig = {
+      enabled: true,
+      windowMinutes: 10,
+      maxEntries: 3, // Only keep 3 events
+    };
+
+    const { result } = renderHook(() => useRecentActivity(testRootPath, smallConfig));
+
+    // Emit 5 events
+    act(() => {
+      for (let i = 1; i <= 5; i++) {
+        events.emit('watcher:change', {
+          type: 'add',
+          path: `/test/workspace/file${i}.txt`,
+        });
+        vi.advanceTimersByTime(100);
+      }
+    });
+
+    // Should only keep the 3 newest events
+    expect(result.current.recentEvents).toHaveLength(3);
+
+    // Should have the 3 most recent files (5, 4, 3)
+    expect(result.current.recentEvents[0].path).toBe('file5.txt');
+    expect(result.current.recentEvents[1].path).toBe('file4.txt');
+    expect(result.current.recentEvents[2].path).toBe('file3.txt');
+  });
+
+  it('prunes events older than windowMinutes', () => {
+    const config: RecentActivityConfig = {
+      enabled: true,
+      windowMinutes: 5, // 5 minutes window
+      maxEntries: 50,
+    };
+
+    const { result } = renderHook(() => useRecentActivity(testRootPath, config));
+
+    // Emit an event
+    act(() => {
+      events.emit('watcher:change', {
+        type: 'add',
+        path: '/test/workspace/old-file.txt',
+      });
+    });
+
+    expect(result.current.recentEvents).toHaveLength(1);
+
+    // Advance time by 6 minutes (beyond the window) and emit new event
+    act(() => {
+      vi.advanceTimersByTime(6 * 60 * 1000);
+      events.emit('watcher:change', {
+        type: 'add',
+        path: '/test/workspace/new-file.txt',
+      });
+    });
+
+    expect(result.current.recentEvents).toHaveLength(1);
+
+    // Old event should be pruned, only new event remains
+    expect(result.current.recentEvents[0].path).toBe('new-file.txt');
+  });
+
+  it('automatically prunes old events via interval', () => {
+    const config: RecentActivityConfig = {
+      enabled: true,
+      windowMinutes: 1, // 1 minute window
+      maxEntries: 50,
+    };
+
+    const { result } = renderHook(() => useRecentActivity(testRootPath, config));
+
+    // Emit an event
+    act(() => {
+      events.emit('watcher:change', {
+        type: 'add',
+        path: '/test/workspace/file.txt',
+      });
+    });
+
+    expect(result.current.recentEvents).toHaveLength(1);
+
+    // Advance time by 2 minutes (beyond the window) - trigger the interval
+    act(() => {
+      vi.advanceTimersByTime(2 * 60 * 1000);
+    });
+
+    // Event should be automatically pruned by interval
+    expect(result.current.recentEvents).toHaveLength(0);
+  });
+
+  it('clears all events when clearEvents is called', () => {
+    const { result } = renderHook(() => useRecentActivity(testRootPath, defaultConfig));
+
+    // Emit multiple events
+    act(() => {
+      events.emit('watcher:change', { type: 'add', path: '/test/workspace/file1.txt' });
+      events.emit('watcher:change', { type: 'add', path: '/test/workspace/file2.txt' });
+      events.emit('watcher:change', { type: 'add', path: '/test/workspace/file3.txt' });
+    });
+
+    expect(result.current.recentEvents).toHaveLength(3);
+
+    // Clear events
+    act(() => {
+      result.current.clearEvents();
+    });
+
+    expect(result.current.recentEvents).toHaveLength(0);
+    expect(result.current.lastEvent).toBeNull();
+  });
+
+  it('does not capture events when enabled is false', () => {
+    const disabledConfig: RecentActivityConfig = {
+      enabled: false,
+      windowMinutes: 10,
+      maxEntries: 50,
+    };
+
+    const { result } = renderHook(() => useRecentActivity(testRootPath, disabledConfig));
+
+    // Emit events
+    act(() => {
+      events.emit('watcher:change', { type: 'add', path: '/test/workspace/file.txt' });
+    });
+
+    expect(result.current.recentEvents).toHaveLength(0);
+  });
+
+  it('clears events when config changes from enabled to disabled', () => {
+    const { result, rerender } = renderHook(
+      ({ config }) => useRecentActivity(testRootPath, config),
+      {
+        initialProps: { config: { ...defaultConfig, enabled: true } },
+      }
+    );
+
+    // Emit events while enabled
+    act(() => {
+      events.emit('watcher:change', { type: 'add', path: '/test/workspace/file.txt' });
+    });
+
+    expect(result.current.recentEvents).toHaveLength(1);
+
+    // Disable the feature
+    act(() => {
+      rerender({ config: { ...defaultConfig, enabled: false } });
+    });
+
+    expect(result.current.recentEvents).toHaveLength(0);
+  });
+
+  it('re-enables and captures events when config changes from disabled to enabled', () => {
+    const { result, rerender } = renderHook(
+      ({ config }) => useRecentActivity(testRootPath, config),
+      {
+        initialProps: { config: { ...defaultConfig, enabled: false } },
+      }
+    );
+
+    // Emit event while disabled - should not be captured
+    act(() => {
+      events.emit('watcher:change', { type: 'add', path: '/test/workspace/file1.txt' });
+    });
+
+    expect(result.current.recentEvents).toHaveLength(0);
+
+    // Re-enable the feature
+    act(() => {
+      rerender({ config: { ...defaultConfig, enabled: true } });
+    });
+
+    // Emit event after re-enabling - should be captured
+    act(() => {
+      events.emit('watcher:change', { type: 'add', path: '/test/workspace/file2.txt' });
+    });
+
+    expect(result.current.recentEvents).toHaveLength(1);
+    expect(result.current.recentEvents[0].path).toBe('file2.txt');
+  });
+
+  it('handles paths outside workspace root', () => {
+    const { result } = renderHook(() => useRecentActivity(testRootPath, defaultConfig));
+
+    // Emit event with path outside workspace
+    act(() => {
+      events.emit('watcher:change', {
+        type: 'add',
+        path: '/different/workspace/file.txt',
+      });
+    });
+
+    expect(result.current.recentEvents).toHaveLength(1);
+    // Path should be converted to relative path (will start with ../)
+    // path.relative('/test/workspace', '/different/workspace/file.txt') = '../../different/workspace/file.txt'
+    expect(result.current.recentEvents[0].path).toBe('../../different/workspace/file.txt');
+  });
+
+  it('unsubscribes from events on unmount', () => {
+    const { result, unmount } = renderHook(() => useRecentActivity(testRootPath, defaultConfig));
+
+    // Emit event before unmount
+    act(() => {
+      events.emit('watcher:change', { type: 'add', path: '/test/workspace/file1.txt' });
+    });
+
+    expect(result.current.recentEvents).toHaveLength(1);
+
+    // Unmount the hook
+    unmount();
+
+    // Emit event after unmount - should not throw or affect anything
+    act(() => {
+      events.emit('watcher:change', { type: 'add', path: '/test/workspace/file2.txt' });
+    });
+
+    // No assertions here - we just verify no errors are thrown
+  });
+
+  it('handles all event types correctly', () => {
+    const { result } = renderHook(() => useRecentActivity(testRootPath, defaultConfig));
+
+    const eventTypes: Array<'add' | 'change' | 'unlink' | 'addDir' | 'unlinkDir'> = [
+      'add',
+      'change',
+      'unlink',
+      'addDir',
+      'unlinkDir',
+    ];
+
+    // Emit one event of each type
+    act(() => {
+      eventTypes.forEach((type, index) => {
+        events.emit('watcher:change', {
+          type,
+          path: `/test/workspace/file${index}.txt`,
+        });
+        vi.advanceTimersByTime(10);
+      });
+    });
+
+    expect(result.current.recentEvents).toHaveLength(5);
+
+    // Verify all types are captured correctly (in reverse order - newest first)
+    eventTypes.reverse().forEach((type, index) => {
+      expect(result.current.recentEvents[index].type).toBe(type);
+    });
+  });
+
+  it('handles paths with special characters', () => {
+    const { result } = renderHook(() => useRecentActivity(testRootPath, defaultConfig));
+
+    act(() => {
+      events.emit('watcher:change', {
+        type: 'add',
+        path: '/test/workspace/src/file with spaces.tsx',
+      });
+    });
+
+    expect(result.current.recentEvents).toHaveLength(1);
+    expect(result.current.recentEvents[0].path).toBe('src/file with spaces.tsx');
+  });
+
+  it('maintains correct order after deduplication', () => {
+    const { result } = renderHook(() => useRecentActivity(testRootPath, defaultConfig));
+
+    // Emit events: file1, file2, file3
+    act(() => {
+      events.emit('watcher:change', { type: 'add', path: '/test/workspace/file1.txt' });
+      vi.advanceTimersByTime(100);
+      events.emit('watcher:change', { type: 'add', path: '/test/workspace/file2.txt' });
+      vi.advanceTimersByTime(100);
+      events.emit('watcher:change', { type: 'add', path: '/test/workspace/file3.txt' });
+    });
+
+    expect(result.current.recentEvents).toHaveLength(3);
+
+    // Update file1 (should move to top)
+    act(() => {
+      vi.advanceTimersByTime(100);
+      events.emit('watcher:change', { type: 'change', path: '/test/workspace/file1.txt' });
+    });
+
+    expect(result.current.recentEvents).toHaveLength(3);
+
+    // Order should now be: file1 (updated), file3, file2
+    expect(result.current.recentEvents[0].path).toBe('file1.txt');
+    expect(result.current.recentEvents[0].type).toBe('change');
+    expect(result.current.recentEvents[1].path).toBe('file3.txt');
+    expect(result.current.recentEvents[2].path).toBe('file2.txt');
+  });
+});


### PR DESCRIPTION
## Summary

Establishes the foundational infrastructure for the Recent Activity feature, enabling temporal view of file system changes. This task creates the data layer (types, hook, configuration) without UI components.

Closes #95

## Changes Made

- Add `ActivityEvent` and `RecentActivityConfig` types for activity tracking
- Create `useRecentActivity` hook with ring buffer implementation
  - Subscribes to `watcher:change` events from event bus
  - Converts absolute paths to workspace-relative paths
  - Maintains ring buffer with time-based and size-based pruning
  - Deduplicates events for same path (keeps only latest)
  - Automatic cleanup via 1-minute interval
- Add `recentActivity` config validation and merging in `src/utils/config.ts`
  - Defaults: `enabled=true`, `windowMinutes=10`, `maxEntries=50`
  - Validates configuration type and range constraints
- Add comprehensive test suite (16 tests) covering:
  - Event capture and path conversion
  - Deduplication and ordering logic
  - Time-based and size-based pruning
  - Feature enable/disable and re-enable flows
  - Edge cases (out-of-workspace paths, special characters)

## Implementation Notes

Building foundation for Recent Activity feature to show temporal view of file system changes. Creating data layer infrastructure without UI components. Using existing watcher system as event source.

**Ring buffer features:**
- Time-based pruning (removes events older than `windowMinutes`)
- Size-based pruning (keeps maximum `maxEntries`)
- Deduplication (same path = keep only latest event)
- Automatic cleanup via 1-minute interval

**Hook integration:**
- Subscribes to `watcher:change` events from event bus
- Converts absolute paths to workspace-relative paths
- Configuration with sensible defaults:
  - `enabled: true` (feature on by default)
  - `windowMinutes: 10` (10-minute rolling window)
  - `maxEntries: 50` (maximum 50 events)

## Follow-up Tasks

- UI components for displaying recent activity (separate PR/issue)
- Consider adding keyboard shortcut to view recent activity modal
- Potential enhancement: group rapid changes to same file with frequency count