### PR TITLE
Implement fully functional configurable right-click context menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { WorktreePanel } from './components/WorktreePanel.js';
 import { HelpModal } from './components/HelpModal.js';
 import { AppErrorBoundary } from './components/AppErrorBoundary.js';
 import type { CanopyConfig, Notification, Worktree } from './types/index.js';
+import type { CommandServices } from './commands/types.js';
 import { useCommandExecutor } from './hooks/useCommandExecutor.js';
 import { useKeyboard } from './hooks/useKeyboard.js';
 import { useFileTree } from './hooks/useFileTree.js';
@@ -28,6 +29,9 @@ import { events, type ModalId, type ModalContextMap } from './services/events.js
 import { clearTerminalScreen } from './utils/terminal.js';
 import { ThemeProvider } from './theme/ThemeProvider.js';
 import { detectTerminalTheme } from './theme/colorPalette.js';
+import { execa } from 'execa';
+import open from 'open';
+import clipboardy from 'clipboardy';
 
 interface AppProps {
   cwd: string;
@@ -702,29 +706,55 @@ const AppContent: React.FC<AppProps> = ({ cwd, config: initialConfig, noWatch, n
         activeRootPath={activeRootPath}
         commandMode={commandMode}
       />
-      {contextMenuOpen && (
-        <ContextMenu
-          path={contextMenuTarget}
-          rootPath={activeRootPath}
-          position={contextMenuPosition}
-          config={config}
-          onClose={() => events.emit('ui:modal:close', { id: 'context-menu' })}
-          onAction={(actionType, result) => {
-            if (result.success) {
-              events.emit('ui:notify', {
-                type: 'success',
-                message: result.message || 'Action completed',
-              });
-            } else {
-              events.emit('ui:notify', {
-                type: 'error',
-                message: `Failed to switch worktree: ${result.message || 'Unknown error'}`,
-              });
+      {contextMenuOpen && (() => {
+        // Create CommandServices object for context menu
+        const contextMenuServices: CommandServices = {
+          ui: {
+            notify: (n: Notification) => events.emit('ui:notify', n),
+            refresh: refreshTree,
+            exit: exitApp,
+          },
+          system: {
+            cwd: activeRootPath,
+            openExternal: async (path) => { await open(path); },
+            copyToClipboard: async (text) => { await clipboardy.write(text); },
+            exec: async (cmd, cmdArgs, execCwd) => {
+              const { stdout } = await execa(cmd, cmdArgs || [], { cwd: execCwd || activeRootPath });
+              return stdout;
             }
-            events.emit('ui:modal:close', { id: 'context-menu' });
-          }}
-        />
-      )}
+          },
+          state: {
+            selectedPath,
+            fileTree: rawTree,
+            expandedPaths: expandedFolders
+          }
+        };
+
+        return (
+          <ContextMenu
+            path={contextMenuTarget}
+            rootPath={activeRootPath}
+            position={contextMenuPosition}
+            config={config}
+            services={contextMenuServices}
+            onClose={() => events.emit('ui:modal:close', { id: 'context-menu' })}
+            onAction={(actionType, result) => {
+              if (result.success) {
+                events.emit('ui:notify', {
+                  type: 'success',
+                  message: result.message || 'Action completed',
+                });
+              } else {
+                events.emit('ui:notify', {
+                  type: 'error',
+                  message: `Action failed: ${result.message || 'Unknown error'}`,
+                });
+              }
+              events.emit('ui:modal:close', { id: 'context-menu' });
+            }}
+          />
+        );
+      })()}
       {isWorktreePanelOpen && (
         <WorktreePanel
           worktrees={enrichedWorktrees}

--- a/src/hooks/useMouse.ts
+++ b/src/hooks/useMouse.ts
@@ -121,25 +121,9 @@ export function useMouse(options: UseMouseOptions): UseMouseReturn {
           // Directories: always toggle expansion
           onToggle(node.path);
         } else {
-          // Files: Copy path logic with X-coordinate bounds check
-          // 1. Calculate Start X: Depth * Indent
-          const indent = config.treeIndent || 2;
-          const startX = node.depth * indent;
-
-          // 2. Calculate End X: Start + Icon (2 chars) + Name length
-          // The icon is roughly 2 chars (Icon glyph + space)
-          const endX = startX + 2 + node.name.length;
-
-          // 3. Only trigger if click is within the Icon or Name
-          if (event.x >= startX && event.x <= endX) {
-            events.emit('file:copy-path', { path: node.path });
-          }
+          // Files: select the file (removed copy-path behavior)
+          onSelect(node.path);
         }
-      }
-
-      // Middle-click: Copy path
-      if (event.button === 'middle') {
-        events.emit('file:copy-path', { path: node.path });
       }
     },
     [getRowIndexFromY, fileTree, onToggle, onOpen, onSelect, onContextMenu, config],

--- a/src/types/contextMenu.ts
+++ b/src/types/contextMenu.ts
@@ -1,0 +1,69 @@
+import type { CommandServices } from '../commands/types.js';
+
+export type ContextMenuItemType = 'action' | 'separator' | 'submenu' | 'command';
+
+export type ContextMenuScope = 'file' | 'folder' | 'both';
+
+/**
+ * An executable action in the context menu.
+ * Executes directly via a function.
+ */
+export interface ContextMenuAction {
+	id: string;
+	label: string;
+	scope: ContextMenuScope;
+	icon?: string; // Optional emoji/icon
+	shortcut?: string; // Display shortcut hint (e.g., "⌘C")
+	execute: (path: string, services: CommandServices) => Promise<void>;
+	matchPattern?: string; // Glob pattern to match files (JSON serializable condition)
+}
+
+/**
+ * A slash command integration in the context menu.
+ * Executes by invoking a registered command.
+ */
+export interface ContextMenuCommand {
+	id: string;
+	label: string;
+	scope: ContextMenuScope;
+	icon?: string;
+	commandName: string; // Slash command to execute (e.g., "copytree")
+	args?: string[]; // Arguments to pass (file path auto-appended)
+	matchPattern?: string; // Glob pattern to match files
+}
+
+/**
+ * A visual separator between menu items.
+ */
+export interface ContextMenuSeparator {
+	id: string;
+	scope: ContextMenuScope;
+}
+
+/**
+ * A submenu containing nested menu items.
+ */
+export interface ContextMenuSubmenu {
+	id: string;
+	label: string;
+	scope: ContextMenuScope;
+	icon?: string;
+	items: ContextMenuItem[];
+}
+
+/**
+ * Union type representing any context menu item.
+ */
+export type ContextMenuItem =
+	| ({ type: 'action' } & ContextMenuAction)
+	| ({ type: 'command' } & ContextMenuCommand)
+	| ({ type: 'separator' } & ContextMenuSeparator)
+	| ({ type: 'submenu' } & ContextMenuSubmenu);
+
+/**
+ * User-configurable context menu settings.
+ */
+export interface ContextMenuConfig {
+	items?: ContextMenuItem[]; // User-defined custom items
+	disableDefaults?: string[]; // IDs of default items to hide
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -97,6 +97,11 @@ export interface RecentActivityConfig {
   maxEntries: number;
 }
 
+/**
+ * Import context menu configuration types
+ */
+import type { ContextMenuConfig } from './contextMenu.js';
+
 export interface CanopyConfig {
   editor: string;
   editorArgs: string[];
@@ -131,6 +136,7 @@ export interface CanopyConfig {
     refreshIntervalMs?: number; // Optional: auto-refresh interval (0 = disabled)
   };
   recentActivity?: RecentActivityConfig;
+  contextMenu?: ContextMenuConfig;
 }
 
 export interface CanopyState {

--- a/src/utils/contextMenuActions.ts
+++ b/src/utils/contextMenuActions.ts
@@ -1,0 +1,291 @@
+import path from 'path';
+import { execa } from 'execa';
+import { runCopyTree } from './copytree.js';
+import { copyFilePath, copyToClipboard } from './clipboard.js';
+import { openFile } from './fileOpener.js';
+import type { ContextMenuItem } from '../types/contextMenu.js';
+import type { CanopyConfig } from '../types/index.js';
+
+/**
+ * Get platform-specific label for the "Reveal in file manager" action.
+ */
+function getPlatformRevealLabel(): string {
+	const platform = process.platform;
+	if (platform === 'darwin') return 'Reveal in Finder';
+	if (platform === 'win32') return 'Reveal in Explorer';
+	return 'Reveal in File Manager';
+}
+
+/**
+ * Get platform-specific label for the "Open Terminal Here" action.
+ */
+function getPlatformTerminalLabel(): string {
+	const platform = process.platform;
+	if (platform === 'darwin') return 'Open Terminal Here';
+	if (platform === 'win32') return 'Open Command Prompt Here';
+	return 'Open Terminal Here';
+}
+
+/**
+ * Open the parent directory of a file in the system file manager,
+ * with the file selected if possible.
+ */
+async function revealInFileManager(filePath: string): Promise<void> {
+	const platform = process.platform;
+
+	try {
+		if (platform === 'darwin') {
+			// macOS: Use 'open -R' to reveal in Finder with file selected
+			await execa('open', ['-R', filePath]);
+		} else if (platform === 'win32') {
+			// Windows: Use 'explorer /select' to open Explorer with file selected
+			await execa('explorer', ['/select,', filePath]);
+		} else {
+			// Linux/Unix: Open parent directory (can't select file in most file managers)
+			const parentDir = path.dirname(filePath);
+			await execa('xdg-open', [parentDir]);
+		}
+	} catch (error) {
+		throw new Error(
+			`Failed to reveal in file manager: ${(error as Error).message}`
+		);
+	}
+}
+
+/**
+ * Open a terminal in the specified directory.
+ */
+async function openTerminalHere(dirPath: string): Promise<void> {
+	const platform = process.platform;
+
+	try {
+		if (platform === 'darwin') {
+			// macOS: Open Terminal.app with the directory
+			await execa('open', ['-a', 'Terminal', dirPath]);
+		} else if (platform === 'win32') {
+			// Windows: Open cmd.exe in the directory
+			await execa('cmd', ['/c', 'start', 'cmd.exe', '/K', `cd /d "${dirPath}"`]);
+		} else {
+			// Linux/Unix: Try to open default terminal (varies by distro)
+			// Common terminals: gnome-terminal, xterm, konsole
+			try {
+				await execa('gnome-terminal', ['--working-directory', dirPath]);
+			} catch {
+				try {
+					await execa('xterm', ['-e', `cd "${dirPath}" && bash`]);
+				} catch {
+					// Fallback: just open file manager
+					await execa('xdg-open', [dirPath]);
+				}
+			}
+		}
+	} catch (error) {
+		throw new Error(`Failed to open terminal: ${(error as Error).message}`);
+	}
+}
+
+/**
+ * Build "Open with..." submenu items based on configured openers.
+ */
+function buildOpenWithSubmenu(
+	config: CanopyConfig,
+	filePath: string
+): ContextMenuItem[] {
+	const items: ContextMenuItem[] = [];
+	const openers = config.openers;
+
+	if (!openers) {
+		return items;
+	}
+
+	// Add default opener
+	items.push({
+		type: 'action',
+		id: 'open-default',
+		label: `${openers.default.cmd} (default)`,
+		scope: 'file',
+		execute: async (path, services) => {
+			await openFile(path, config, openers.default);
+		},
+	});
+
+	// Add extension-based openers
+	const ext = path.extname(filePath);
+	if (ext && openers.byExtension?.[ext]) {
+		const extensionOpener = openers.byExtension[ext];
+		items.push({
+			type: 'action',
+			id: `open-ext-${ext}`,
+			label: `${extensionOpener.cmd} (for ${ext})`,
+			scope: 'file',
+			execute: async (path, services) => {
+				await openFile(path, config, extensionOpener);
+			},
+		});
+	}
+
+	// Add glob-based openers that match this file
+	if (openers.byGlob) {
+		for (const [pattern, opener] of Object.entries(openers.byGlob)) {
+			// Simple pattern matching (could use minimatch for better accuracy)
+			const simplifiedPattern = pattern.replace('**/', '').replace('/*', '');
+			if (filePath.includes(simplifiedPattern)) {
+				items.push({
+					type: 'action',
+					id: `open-glob-${pattern}`,
+					label: `${opener.cmd} (for ${pattern})`,
+					scope: 'file',
+					execute: async (path, services) => {
+						await openFile(path, config, opener);
+					},
+				});
+			}
+		}
+	}
+
+	// Add "Back" option
+	items.push({
+		type: 'action',
+		id: 'back',
+		label: '← Back',
+		scope: 'file',
+		execute: async () => {
+			// Handled by ContextMenu component (navigate back in stack)
+		},
+	});
+
+	return items;
+}
+
+/**
+ * Get default context menu items for files.
+ * These are the standard file operations.
+ */
+export function getDefaultFileActions(
+	config: CanopyConfig,
+	filePath: string
+): ContextMenuItem[] {
+	return [
+		{
+			type: 'action',
+			id: 'open',
+			label: 'Open',
+			scope: 'file',
+			icon: '📂',
+			execute: async (path, services) => {
+				await openFile(path, config);
+			},
+		},
+		{
+			type: 'submenu',
+			id: 'open-with',
+			label: 'Open with...',
+			scope: 'file',
+			icon: '⚙️',
+			items: buildOpenWithSubmenu(config, filePath),
+		},
+		{
+			type: 'separator',
+			id: 'sep-1',
+			scope: 'both',
+		},
+		{
+			type: 'action',
+			id: 'copy-filename',
+			label: 'Copy filename',
+			scope: 'both',
+			icon: '📋',
+			execute: async (filePath, services) => {
+				const filename = path.basename(filePath);
+				await copyToClipboard(filename);
+			},
+		},
+		{
+			type: 'action',
+			id: 'copy-relative',
+			label: 'Copy relative path',
+			scope: 'both',
+			icon: '📋',
+			shortcut: 'c',
+			execute: async (filePath, services) => {
+				await copyFilePath(filePath, services.system.cwd, true);
+			},
+		},
+		{
+			type: 'action',
+			id: 'copy-absolute',
+			label: 'Copy absolute path',
+			scope: 'both',
+			icon: '📋',
+			execute: async (filePath, services) => {
+				await copyFilePath(filePath, services.system.cwd, false);
+			},
+		},
+		{
+			type: 'separator',
+			id: 'sep-2',
+			scope: 'both',
+		},
+		{
+			type: 'action',
+			id: 'reveal',
+			label: getPlatformRevealLabel(),
+			scope: 'both',
+			icon: '👁️',
+			execute: async (filePath) => {
+				await revealInFileManager(filePath);
+			},
+		},
+	];
+}
+
+/**
+ * Get default context menu items for folders.
+ * These are folder-specific operations.
+ */
+export function getDefaultFolderActions(): ContextMenuItem[] {
+	return [
+		{
+			type: 'command',
+			id: 'copytree',
+			label: 'Run CopyTree',
+			scope: 'folder',
+			icon: '🌲',
+			commandName: 'copytree',
+			args: [],
+		},
+		{
+			type: 'action',
+			id: 'open-terminal',
+			label: getPlatformTerminalLabel(),
+			scope: 'folder',
+			icon: '💻',
+			execute: async (dirPath, services) => {
+				await openTerminalHere(dirPath);
+			},
+		},
+		{
+			type: 'separator',
+			id: 'sep-folder',
+			scope: 'folder',
+		},
+	];
+}
+
+/**
+ * Merge default actions with user-configured custom actions.
+ * Filters out disabled default items.
+ */
+export function mergeContextMenuItems(
+	defaults: ContextMenuItem[],
+	customItems: ContextMenuItem[] = [],
+	disabledIds: string[] = []
+): ContextMenuItem[] {
+	// Filter out disabled default items
+	const enabledDefaults = defaults.filter(
+		(item) => !disabledIds.includes(item.id)
+	);
+
+	// Append custom items
+	return [...enabledDefaults, ...customItems];
+}

--- a/tests/hooks/useMouse.test.ts
+++ b/tests/hooks/useMouse.test.ts
@@ -69,8 +69,9 @@ describe('useMouse', () => {
       expect(onToggle).toHaveBeenCalledWith('src');
     });
 
-    it('emits file:copy-path event on left-click', () => {
-      const options = createOptions();
+    it('calls onSelect on left-click for files', () => {
+      const onSelect = vi.fn();
+      const options = createOptions({ onSelect });
       render(React.createElement(TestComponent, options));
 
       const { handleClick } = (global as any).testHandlers;
@@ -84,10 +85,10 @@ describe('useMouse', () => {
         meta: false,
       });
 
-      expect(emitSpy).toHaveBeenCalledWith('file:copy-path', { path: 'src/App.tsx' });
+      expect(onSelect).toHaveBeenCalledWith('src/App.tsx');
     });
 
-    it('does not call onOpen or onSelect on left-click (emits copy event instead)', () => {
+    it('calls onSelect on left-click for files (not copy event)', () => {
       const onOpen = vi.fn();
       const onSelect = vi.fn();
       const options = createOptions({ onOpen, onSelect });
@@ -105,10 +106,10 @@ describe('useMouse', () => {
         meta: false,
       });
 
-      // Should emit copy event, not call onOpen or onSelect
-      expect(emitSpy).toHaveBeenCalledWith('file:copy-path', { path: 'src/App.tsx' });
+      // Should call onSelect, not emit copy event
+      expect(onSelect).toHaveBeenCalledWith('src/App.tsx');
       expect(onOpen).not.toHaveBeenCalled();
-      expect(onSelect).not.toHaveBeenCalled();
+      expect(emitSpy).not.toHaveBeenCalledWith('file:copy-path', expect.anything());
     });
 
     it('opens context menu on right-click', () => {
@@ -196,33 +197,14 @@ describe('useMouse', () => {
       expect(onToggle).toHaveBeenCalledWith('src/utils');
     });
 
-    it('emits file:copy-path on middle-click', () => {
-      const options = createOptions();
+    it('selects file on left-click regardless of x position', () => {
+      const onSelect = vi.fn();
+      const options = createOptions({ onSelect });
       render(React.createElement(TestComponent, options));
 
       const { handleClick } = (global as any).testHandlers;
 
-      handleClick({
-        x: 3,
-        y: 2,
-        button: 'middle',
-        shift: false,
-        ctrl: false,
-        meta: false,
-      });
-
-      expect(emitSpy).toHaveBeenCalledWith('file:copy-path', { path: 'src/App.tsx' });
-    });
-
-    it('does not emit copy event when clicking outside file name bounds', () => {
-      const options = createOptions();
-      render(React.createElement(TestComponent, options));
-
-      const { handleClick } = (global as any).testHandlers;
-
-      // Click far to the right, beyond the file name
-      // App.tsx is at depth 1, so indent is 2, icon is 2 chars, name is 7 chars = endX is 11
-      // Clicking at x=20 should not trigger copy
+      // Click anywhere on the file row - should select
       handleClick({
         x: 20,
         y: 2,
@@ -232,7 +214,7 @@ describe('useMouse', () => {
         meta: false,
       });
 
-      expect(emitSpy).not.toHaveBeenCalledWith('file:copy-path', expect.anything());
+      expect(onSelect).toHaveBeenCalledWith('src/App.tsx');
     });
   });
 


### PR DESCRIPTION
## Summary

This PR transforms the existing context menu into a comprehensive, configurable right-click action system with support for folder-specific actions, custom menu items, and slash command integration.

Closes #106

## Changes Made

- Add comprehensive type definitions in src/types/contextMenu.ts
- Create default action registry in src/utils/contextMenuActions.ts
- Add folder-specific actions: Run CopyTree, Open Terminal, Copy Filename
- Implement stack-based submenu navigation for "Open with..." menus
- Remove left-click copy behavior (now uses context menu or 'c' key)
- Add contextMenu configuration support in CanopyConfig
- Wire up CommandServices for context menu integration with slash commands
- Update tests to reflect new behavior and menu structure

## Implementation Notes

### Context & rationale

* Transform existing non-functional context menu into comprehensive, configurable system
* Add folder-specific actions (CopyTree, Reveal in Finder/Explorer, Open Terminal)
* Remove left-click copy path behavior in favor of dedicated context menu action
* Enable custom menu items via configuration with slash command integration
* Use glob patterns for conditional menu items instead of functions (JSON serializable)

### Implementation details

* Created `src/types/contextMenu.ts` with type definitions for menu system
* Created `src/utils/contextMenuActions.ts` with default action registry
* Added folder actions: "Run CopyTree", "Reveal in Finder/Explorer", "Open Terminal Here"
* Added file action: "Copy Filename" (in addition to existing path copy options)
* Implemented stack-based submenu navigation for "Open with..." menus
* Used glob patterns (`matchPattern`) for conditional menu items (JSON serializable)
* Platform-specific labels and commands (macOS/Windows/Linux)

## Breaking Changes & Migration Hints

### Breaking changes

* Left-click no longer copies path (moved to right-click context menu)

### Migration hints

* Users should use 'c' keyboard shortcut or right-click context menu for copying paths
* Left-click now used purely for selection/opening (standard UI behavior)

## Follow-up Tasks

* Multi-select support (Shift+click to select range) - future enhancement
* Deeper nested submenus (current implementation supports one level)
* Action conditions based on file extension patterns
* Keyboard shortcuts for menu items (press number for quick select)