### PR TITLE
feat(git): add git-only view mode with auto-expand

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -16,6 +16,9 @@ interface HeaderProps {
   identity: ProjectIdentity;
   config: CanopyConfig;
   isSwitching?: boolean;
+  gitOnlyMode?: boolean;
+  onToggleGitOnlyMode?: () => void;
+  gitEnabled?: boolean;
 }
 
 export const Header: React.FC<HeaderProps> = ({
@@ -28,6 +31,9 @@ export const Header: React.FC<HeaderProps> = ({
   identity,
   config,
   isSwitching = false,
+  gitOnlyMode = false,
+  onToggleGitOnlyMode,
+  gitEnabled = true,
 }) => {
   const { palette } = useTheme();
   // Note: Keyboard handling for worktree actions (w/W keys) is delegated to
@@ -62,8 +68,11 @@ export const Header: React.FC<HeaderProps> = ({
     ? worktreeName.slice(0, maxBranchLength - 1) + '…'
     : worktreeName;
 
+  // Show git-only mode button only when git is enabled
+  const showGitOnlyButton = gitEnabled && onToggleGitOnlyMode !== undefined;
+
   return (
-    <Box borderStyle="single" paddingX={1}>
+    <Box borderStyle="single" borderColor={gitOnlyMode ? palette.alert.warning : undefined} paddingX={1}>
       <Text>{identity.emoji} </Text>
 
       {/* Dynamic Gradient and Title */}
@@ -103,6 +112,20 @@ export const Header: React.FC<HeaderProps> = ({
               )}
             </React.Fragment>
           ))}
+        </>
+      )}
+
+      {/* Git-only mode toggle button */}
+      {showGitOnlyButton && (
+        <>
+          <Text dimColor> </Text>
+          <Text
+            color={gitOnlyMode ? palette.alert.warning : palette.accent.secondary}
+            bold
+            underline
+          >
+            [{gitOnlyMode ? 'Git' : 'All'}]
+          </Text>
         </>
       )}
 

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -70,6 +70,7 @@ export function HelpModal({ visible, onClose }: HelpModalProps): React.JSX.Eleme
       <Box flexDirection="column" marginBottom={1}>
         <Text bold color={palette.accent.primary}>Git:</Text>
         <Text>  <Text color={palette.semantic.srcFolder}>g</Text>           Toggle git status markers</Text>
+        <Text>  <Text color={palette.semantic.srcFolder}>G</Text>           Toggle Git-only view (show only changed files)</Text>
       </Box>
 
       {/* Copy/CopyTree */}

--- a/src/hooks/useAppLifecycle.ts
+++ b/src/hooks/useAppLifecycle.ts
@@ -17,6 +17,7 @@ export interface LifecycleState {
   activeRootPath: string;
   initialSelectedPath: string | null;
   initialExpandedFolders: Set<string>;
+  initialGitOnlyMode: boolean;
   error: Error | null;
 }
 
@@ -59,6 +60,7 @@ export function useAppLifecycle({
     activeRootPath: cwd,
     initialSelectedPath: null,
     initialExpandedFolders: new Set<string>(),
+    initialGitOnlyMode: false,
     error: null,
   });
 
@@ -123,6 +125,7 @@ export function useAppLifecycle({
       let activeRootPath = cwd;
       let initialSelectedPath: string | null = null;
       let initialExpandedFolders = new Set<string>();
+      let initialGitOnlyMode = false;
 
       if (noGit) {
         // Git completely disabled - skip all git operations
@@ -145,6 +148,7 @@ export function useAppLifecycle({
           // Always store initial state for session restoration
           initialSelectedPath = initialState.selectedPath;
           initialExpandedFolders = initialState.expandedFolders;
+          initialGitOnlyMode = initialState.gitOnlyMode;
         } catch (error) {
           // Check if this is a truly catastrophic error (not just "not a git repo")
           const errorMessage = (error as Error).message;
@@ -173,6 +177,7 @@ export function useAppLifecycle({
           activeRootPath,
           initialSelectedPath,
           initialExpandedFolders,
+          initialGitOnlyMode,
           error: null,
         });
       }

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -22,6 +22,7 @@ export interface KeyboardHandlers {
 
   // Git Actions
   onToggleGitStatus?: () => void; // g key
+  onToggleGitOnlyMode?: () => void; // Shift+G key
 
   // Copy Actions
   onOpenCopyTreeBuilder?: () => void;  // Shift+C key
@@ -192,8 +193,13 @@ export function useKeyboard(handlers: KeyboardHandlers): void {
     }
 
     // Git Actions
-    if (input === 'g' && handlers.onToggleGitStatus) {
+    if (input === 'g' && !key.shift && handlers.onToggleGitStatus) {
       handlers.onToggleGitStatus();
+      return;
+    }
+
+    if (input === 'G' && handlers.onToggleGitOnlyMode) {
+      handlers.onToggleGitOnlyMode();
       return;
     }
 

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -12,6 +12,7 @@ export interface InitialState {
   selectedPath: string | null;
   expandedFolders: Set<string>;
   cursorPosition: number;
+  gitOnlyMode: boolean;
 }
 
 /**
@@ -20,6 +21,7 @@ export interface InitialState {
 export interface SessionState {
   selectedPath: string | null;
   expandedFolders: string[];  // Array for JSON serialization
+  gitOnlyMode?: boolean;      // Git-only view mode preference
   timestamp: number;
 }
 
@@ -63,6 +65,7 @@ export async function loadInitialState(
   let selectedPath: string | null = rootPath;
   let expandedFolders = new Set<string>();
   let cursorPosition = 0;
+  let gitOnlyMode = false;
 
   if (sessionState) {
     // Restore null selection if explicitly saved
@@ -79,6 +82,9 @@ export async function loadInitialState(
 
     // Restore expanded folders
     expandedFolders = new Set(sessionState.expandedFolders);
+
+    // Restore git-only mode preference
+    gitOnlyMode = sessionState.gitOnlyMode ?? false;
   }
 
   return {
@@ -86,6 +92,7 @@ export async function loadInitialState(
     selectedPath,
     expandedFolders,
     cursorPosition,
+    gitOnlyMode,
   };
 }
 
@@ -125,7 +132,12 @@ export async function loadSessionState(
     const timestampValid =
       typeof raw.timestamp === 'number' && Number.isFinite(raw.timestamp);
 
-    if (!hasValidSelectedPath || !expandedFoldersValid || !timestampValid) {
+    // Optional gitOnlyMode field - only validate if present
+    const gitOnlyModeValid =
+      !Object.prototype.hasOwnProperty.call(raw, 'gitOnlyMode') ||
+      typeof raw.gitOnlyMode === 'boolean';
+
+    if (!hasValidSelectedPath || !expandedFoldersValid || !timestampValid || !gitOnlyModeValid) {
       console.warn('Invalid session state format, ignoring');
       return null;
     }
@@ -134,6 +146,7 @@ export async function loadSessionState(
     const data: SessionState = {
       selectedPath: raw.selectedPath,
       expandedFolders: raw.expandedFolders,
+      gitOnlyMode: raw.gitOnlyMode,
       timestamp: raw.timestamp,
     };
 


### PR DESCRIPTION
## Summary

Implements a git-only view mode that filters the tree to show only files with git changes (modified, added, deleted, untracked) and automatically expands all folders containing changes. This provides a focused view for reviewing what has changed in the current worktree.

Closes #99

## Changes Made

- Add git-only mode state management with per-worktree persistence
- Implement auto-expansion of folders containing changes (with >100 file safety check)
- Add [Git]/[All] toggle button in header with yellow border visual indicator
- Add Shift+G keyboard shortcut for toggling git-only mode
- Add empty state component when no changed files exist
- Restore expansion state when exiting git-only mode
- Integrate with existing name filter using AND logic
- Update session state schema to persist git-only mode preference
- Update help modal to document new keyboard shortcut

## Implementation Notes

### Context & Rationale

* Implemented git-only view mode that filters to show only changed files (modified, added, deleted, untracked)
* Auto-expands all folders containing changes for immediate visibility (unless >100 files for performance)
* Mode is persisted per-worktree in session state to maintain preferences across worktree switches
* Added visual indication with yellow header border when in git-only mode to prevent user confusion
* Implemented safety check to prevent performance issues with large changesets (>100 files)
* Mode integrates with existing name filter using AND logic (intersection of filters)

### State Management
* Added `gitOnlyMode` state in App.tsx with initial value from lifecycle
* Extended SessionState interface to include `gitOnlyMode?: boolean` field
* Extended InitialState interface to include `gitOnlyMode: boolean` field
* Modified useAppLifecycle hook to load and expose initialGitOnlyMode from session state

### Auto-Expansion Logic
* Created helper function `collectAllFolderPaths()` to recursively gather all folder paths from tree
* Added `previousExpandedFoldersRef` ref to cache expansion state before entering git-only mode
* When entering git-only mode: caches current expansion, then auto-expands all folders in filtered tree
* When exiting git-only mode: restores previous expansion state from cache
* Safety check: if >100 changed files, skip auto-expansion and show warning notification

### UI Components
* Updated Header.tsx to accept `gitOnlyMode`, `onToggleGitOnlyMode`, and `gitEnabled` props
* Added toggle button showing `[Git]` or `[All]` with yellow color when in git mode
* Header border color changes to yellow when in git-only mode for clear visual feedback
* Added empty state component in App.tsx when no changed files exist in git-only mode
  - Shows "No changed files in this worktree" message
  - Prompts user to press G to switch back to All Files view

### Keyboard & Interaction
* Updated KeyboardHandlers interface to include `onToggleGitOnlyMode?: () => void`
* Implemented Shift+G keyboard handler in useKeyboard.ts
* Updated HelpModal.tsx to document the new `G` shortcut
* Git-only mode button hidden when git is disabled (--no-git flag)

### Session Persistence
* Updated all saveSessionState calls to include gitOnlyMode field:
  - App.tsx cleanup effect
  - handleSwitchWorktree function
  - handleQuit function
* Updated loadSessionState to parse and validate gitOnlyMode field
* When switching worktrees, mode preference is saved and restored per worktree

### Filter Integration
* Git status filter is calculated based on gitOnlyMode state
* When gitOnlyMode is true, passes `['modified', 'added', 'deleted', 'untracked']` to useFileTree
* Integrates seamlessly with existing name filter (AND logic - both filters apply)

## Follow-up Tasks

* Consider adding configuration option for default view mode per worktree type
* Consider making the >100 file threshold configurable
* Potential optimization: lazy folder expansion on-demand for very large changesets