### PR TITLE
feat(recent-activity): integrate hook, component, and keyboard shortcuts

### DIFF
--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -83,6 +83,7 @@ export function HelpModal({ visible, onClose }: HelpModalProps): React.JSX.Eleme
       {/* Misc */}
       <Box flexDirection="column" marginBottom={1}>
         <Text bold color={palette.accent.primary}>Misc:</Text>
+        <Text>  <Text color={palette.semantic.srcFolder}>a</Text>           Open recent activity panel</Text>
         <Text>  <Text color={palette.semantic.srcFolder}>r</Text>           Manual refresh</Text>
         <Text>  <Text color={palette.semantic.srcFolder}>?</Text>           Toggle this help overlay</Text>
         <Text>  <Text color={palette.semantic.srcFolder}>q</Text>           Quit Canopy</Text>

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -215,6 +215,12 @@ export function useKeyboard(handlers: KeyboardHandlers): void {
       return;
     }
 
+    // Recent Activity
+    if (input === 'a' && !key.shift && !key.ctrl && !key.meta) {
+      events.emit('ui:modal:open', { id: 'recent-activity' });
+      return;
+    }
+
     // UI Actions
     if (input === 'r' && handlers.onRefresh) {
       handlers.onRefresh();

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -1,12 +1,13 @@
 import { EventEmitter } from 'events';
 import type { NotificationType } from '../types/index.js';
 
-export type ModalId = 'help' | 'worktree' | 'context-menu' | 'command-bar';
+export type ModalId = 'help' | 'worktree' | 'context-menu' | 'command-bar' | 'recent-activity';
 export interface ModalContextMap {
   help: undefined;
   worktree: undefined;
   'context-menu': { path: string; position?: { x: number; y: number } };
   'command-bar': { initialInput?: string };
+  'recent-activity': undefined;
 }
 
 // 1. Define Payload Types


### PR DESCRIPTION
## Summary

This PR completes the integration of the Recent Activity feature (Task 3), making it fully functional. Users can now press `a` to view recent file changes and navigate directly to files in the tree.

Closes #97

## Changes Made

- Wire useRecentActivity hook to App component
- Render RecentActivityPanel with modal state management
- Add 'a' keyboard shortcut to open recent activity panel
- Implement navigation handler to jump from panel to tree
- Clear activity buffer on worktree switch
- Add recent-activity to modal type definitions
- Document 'a' shortcut in help modal
- Implement ESC priority handling with MODAL_CLOSE_PRIORITY
- Add gitOnlyMode to handleSwitchWorktree dependencies

## Implementation Notes

**Context & rationale:**
- Final integration task that makes the Recent Activity feature fully functional
- Wires up existing hook and component infrastructure to main App
- Adds keyboard shortcut (`a`) to open the panel
- Implements navigation from panel to tree

**Implementation details:**
- Added imports for useRecentActivity hook and RecentActivityPanel component
- Initialized useRecentActivity hook in App.tsx (after useAIStatus)
- Added modal state tracking for recent-activity panel
- Created handleSelectActivityPath handler to navigate from panel to tree
- Integrated clearEvents() call in worktree switch handler
- Rendered RecentActivityPanel conditionally based on modal state
- Added 'a' keyboard shortcut in useKeyboard.ts to open panel
- Updated HelpModal to document 'a' shortcut in Misc section
- Added 'recent-activity' to ModalId type and ModalContextMap in events.ts

**Codex review improvements:**
- Implemented proper ESC priority handling with MODAL_CLOSE_PRIORITY array
- Added gitOnlyMode to handleSwitchWorktree dependency array to ensure session state saves current view mode

## Follow-up Tasks

- Task 4 will add StatusBar indicator and finalize configuration