### PR TITLE
feat: multi-worktree status polling

### DIFF
--- a/src/hooks/useMultiWorktreeStatus.ts
+++ b/src/hooks/useMultiWorktreeStatus.ts
@@ -1,0 +1,238 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { GitStatus, Worktree, WorktreeChanges } from '../types/index.js';
+import {
+  getGitStatusCached,
+  invalidateGitStatusCache,
+  isGitRepository,
+} from '../utils/git.js';
+import { logWarn } from '../utils/logger.js';
+import { events } from '../services/events.js';
+
+export interface MultiWorktreeRefreshConfig {
+  activeMs?: number;
+  backgroundMs?: number;
+}
+
+export interface UseMultiWorktreeStatusReturn {
+  worktreeChanges: Map<string, WorktreeChanges>;
+  refresh: (worktreeId?: string, force?: boolean) => void;
+  clear: () => void;
+}
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+const DEFAULT_ACTIVE_MS = 1500; // 1.5s for active worktree
+const DEFAULT_BACKGROUND_MS = 10000; // 10s for background worktrees
+
+/**
+ * Poll git status for all detected worktrees with smarter intervals.
+ *
+ * - Active worktree: fast refresh (1–2s)
+ * - Background worktrees: slower refresh (10–30s)
+ * - Errors are isolated per worktree so one failure won't affect others
+ */
+export function useMultiWorktreeStatus(
+  worktrees: Worktree[],
+  activeWorktreeId: string | null,
+  refreshConfig: MultiWorktreeRefreshConfig = {},
+  enabled: boolean = true
+): UseMultiWorktreeStatusReturn {
+  const [worktreeChanges, setWorktreeChanges] = useState<
+    Map<string, WorktreeChanges>
+  >(new Map());
+
+  const timersRef = useRef<Map<string, NodeJS.Timeout>>(new Map());
+  const inflightRef = useRef<Map<string, Promise<void>>>(new Map());
+  const mountedRef = useRef<boolean>(true);
+
+  const { activeMs, backgroundMs } = useMemo(() => {
+    const active = clamp(
+      refreshConfig.activeMs ?? DEFAULT_ACTIVE_MS,
+      1000,
+      2000,
+    );
+    const background = clamp(
+      refreshConfig.backgroundMs ?? DEFAULT_BACKGROUND_MS,
+      10000,
+      30000,
+    );
+    return { activeMs: active, backgroundMs: background };
+  }, [refreshConfig.activeMs, refreshConfig.backgroundMs]);
+
+  const clearTimers = useCallback(() => {
+    timersRef.current.forEach(timer => clearInterval(timer));
+    timersRef.current.clear();
+  }, []);
+
+  const setChangesForWorktree = useCallback(
+    (worktreeId: string, changes: WorktreeChanges) => {
+      if (!mountedRef.current) return;
+      setWorktreeChanges(prev => {
+        const next = new Map(prev);
+        next.set(worktreeId, changes);
+        return next;
+      });
+    },
+    [],
+  );
+
+  const fetchStatusForWorktree = useCallback(
+    async (worktree: Worktree, forceRefresh = false) => {
+      if (!enabled) {
+        return;
+      }
+
+      // Prevent overlapping fetches for the same worktree
+      if (inflightRef.current.has(worktree.id)) {
+        return inflightRef.current.get(worktree.id);
+      }
+
+      const fetchPromise = (async () => {
+        try {
+          const isRepo = await isGitRepository(worktree.path);
+          if (!isRepo) {
+            setChangesForWorktree(worktree.id, {
+              worktreeId: worktree.id,
+              rootPath: worktree.path,
+              changes: [],
+              changedFileCount: 0,
+              lastUpdated: Date.now(),
+            });
+            return;
+          }
+
+          if (forceRefresh) {
+            invalidateGitStatusCache(worktree.path);
+          }
+
+          const status = await getGitStatusCached(worktree.path, forceRefresh);
+          const changeList: Array<{ path: string; status: GitStatus }> = [];
+          for (const [path, statusValue] of status.entries()) {
+            changeList.push({ path, status: statusValue });
+          }
+
+          setChangesForWorktree(worktree.id, {
+            worktreeId: worktree.id,
+            rootPath: worktree.path,
+            changes: changeList,
+            changedFileCount: changeList.length,
+            lastUpdated: Date.now(),
+          });
+        } catch (error) {
+          logWarn('Failed to fetch git status for worktree', {
+            worktree: worktree.path,
+            message: (error as Error).message,
+          });
+          // Keep previous state intact; error is isolated to this worktree
+        } finally {
+          inflightRef.current.delete(worktree.id);
+        }
+      })();
+
+      inflightRef.current.set(worktree.id, fetchPromise);
+      return fetchPromise;
+    },
+    [enabled, setChangesForWorktree],
+  );
+
+  const refresh = useCallback(
+    (worktreeId?: string, forceRefresh: boolean = true) => {
+      if (!enabled) {
+        return;
+      }
+
+      if (worktreeId) {
+        const target = worktrees.find(wt => wt.id === worktreeId);
+        if (target) {
+          void fetchStatusForWorktree(target, forceRefresh);
+        }
+        return;
+      }
+
+      for (const wt of worktrees) {
+        void fetchStatusForWorktree(wt, forceRefresh);
+      }
+    },
+    [enabled, fetchStatusForWorktree, worktrees],
+  );
+
+  const clear = useCallback(() => {
+    clearTimers();
+    inflightRef.current.clear();
+    setWorktreeChanges(new Map());
+  }, [clearTimers]);
+
+  // Update polling schedule when worktrees or active ID change
+  useEffect(() => {
+    if (!enabled) {
+      clear();
+      return;
+    }
+
+    // Clean up any previous timers
+    clearTimers();
+
+    // Remove changes for worktrees that no longer exist
+    setWorktreeChanges(prev => {
+      const next = new Map<string, WorktreeChanges>();
+      for (const wt of worktrees) {
+        const existing = prev.get(wt.id);
+        if (existing) {
+          next.set(wt.id, existing);
+        }
+      }
+      return next;
+    });
+
+    for (const wt of worktrees) {
+      // Immediate fetch on (re)subscription
+      void fetchStatusForWorktree(wt, true);
+
+      const intervalMs = wt.id === activeWorktreeId ? activeMs : backgroundMs;
+      if (intervalMs <= 0) continue;
+
+      const timer = setInterval(() => {
+        void fetchStatusForWorktree(wt);
+      }, intervalMs);
+
+      timersRef.current.set(wt.id, timer);
+    }
+
+    return () => {
+      clearTimers();
+    };
+  }, [
+    activeMs,
+    activeWorktreeId,
+    backgroundMs,
+    clear,
+    clearTimers,
+    enabled,
+    fetchStatusForWorktree,
+    worktrees,
+  ]);
+
+  // React to global refresh events
+  useEffect(() => {
+    return events.on('sys:refresh', () => refresh(undefined, true));
+  }, [refresh]);
+
+  useEffect(() => {
+    return events.on('sys:worktree:refresh', () => refresh(undefined, true));
+  }, [refresh]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      clear();
+    };
+  }, [clear]);
+
+  return {
+    worktreeChanges,
+    refresh,
+    clear,
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,14 @@ export type FileType = 'file' | 'directory';
 
 export type NotificationType = 'info' | 'success' | 'error' | 'warning';
 
+export interface WorktreeChanges {
+  worktreeId: string;
+  rootPath: string;
+  changes: Array<{ path: string; status: GitStatus }>;
+  changedFileCount: number;
+  lastUpdated: number;
+}
+
 export interface TreeNode {
   name: string;
   path: string;
@@ -51,6 +59,9 @@ export interface Worktree {
 
   /** Loading state for async summary generation */
   summaryLoading?: boolean;
+
+  /** Recent git status changes for this worktree */
+  changes?: Array<{ path: string; status: GitStatus }>;
 }
 
 export interface OpenerConfig {

--- a/tests/components/TreeNode.test.tsx
+++ b/tests/components/TreeNode.test.tsx
@@ -1,15 +1,10 @@
 import React from 'react';
-import { ThemeProvider } from '../../src/theme/ThemeProvider.js';
 import { render } from 'ink-testing-library';
-import { ThemeProvider } from '../../src/theme/ThemeProvider.js';
 import { describe, it, expect, vi } from 'vitest';
-import { ThemeProvider } from '../../src/theme/ThemeProvider.js';
 import { TreeNode } from '../../src/components/TreeNode.js';
 import { ThemeProvider } from '../../src/theme/ThemeProvider.js';
 import { DEFAULT_CONFIG } from '../../src/types/index.js';
-import { ThemeProvider } from '../../src/theme/ThemeProvider.js';
 import type { TreeNode as TreeNodeType, GitStatus } from '../../src/types/index.js';
-import { ThemeProvider } from '../../src/theme/ThemeProvider.js';
 
 describe('TreeNode', () => {
   const renderWithTheme = (component) => {
@@ -20,7 +15,10 @@ describe('TreeNode', () => {
     );
   };
 
-  const mockConfig = DEFAULT_CONFIG;
+  const mockConfig = {
+    ...DEFAULT_CONFIG,
+    git: { ...(DEFAULT_CONFIG.git || {}), statusStyle: 'letter' },
+  };
   const mockOnSelect = vi.fn();
   const mockOnToggle = vi.fn();
 

--- a/tests/hooks/useMultiWorktreeStatus.test.tsx
+++ b/tests/hooks/useMultiWorktreeStatus.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useMultiWorktreeStatus } from '../../src/hooks/useMultiWorktreeStatus.js';
+import type { Worktree } from '../../src/types/index.js';
+import * as gitUtils from '../../src/utils/git.js';
+
+vi.mock('../../src/utils/git.js');
+
+const makeWorktree = (id: string, path: string): Worktree => ({
+	id,
+	path,
+	name: id,
+	isCurrent: false,
+});
+
+describe('useMultiWorktreeStatus', () => {
+	const worktrees: Worktree[] = [
+		makeWorktree('wt-1', '/repo/wt-1'),
+		makeWorktree('wt-2', '/repo/wt-2'),
+	];
+
+	beforeEach(() => {
+		vi.useFakeTimers({ shouldAdvanceTime: true });
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('polls active worktree faster than background and aggregates changes', async () => {
+		vi.mocked(gitUtils.isGitRepository).mockResolvedValue(true);
+		const callCounts = { active: 0, background: 0 };
+
+		vi.mocked(gitUtils.getGitStatusCached).mockImplementation(async (cwd) => {
+			if (cwd.includes('wt-1')) {
+				callCounts.active += 1;
+				return new Map([['/repo/wt-1/file.txt', 'modified']]);
+			}
+			callCounts.background += 1;
+			return new Map([['/repo/wt-2/other.txt', 'added']]);
+		});
+
+		const { result } = renderHook(() =>
+			useMultiWorktreeStatus(worktrees, 'wt-1', { activeMs: 1000, backgroundMs: 20000 }, true),
+		);
+
+		await waitFor(() => {
+			expect(result.current.worktreeChanges.get('wt-1')?.changedFileCount).toBe(1);
+			expect(result.current.worktreeChanges.get('wt-2')?.changedFileCount).toBe(1);
+			expect(callCounts).toEqual({ active: 1, background: 1 });
+		});
+
+		vi.advanceTimersByTime(1000);
+
+		// Active worktree should refresh again before background interval elapses
+		await waitFor(() => {
+			expect(callCounts.active).toBeGreaterThan(callCounts.background);
+		});
+
+		vi.advanceTimersByTime(19000);
+
+		await waitFor(() => {
+			expect(callCounts.background).toBeGreaterThan(1);
+			expect(callCounts.active).toBeGreaterThan(callCounts.background);
+		});
+	});
+
+	it('isolates errors so one failing worktree does not block others', async () => {
+		vi.mocked(gitUtils.isGitRepository).mockResolvedValue(true);
+		vi.mocked(gitUtils.getGitStatusCached).mockImplementation(async (cwd) => {
+			if (cwd.includes('wt-2')) {
+				throw new Error('boom');
+			}
+			return new Map([['/repo/wt-1/file.txt', 'modified']]);
+		});
+
+		const { result } = renderHook(() =>
+			useMultiWorktreeStatus(worktrees, 'wt-1', { activeMs: 1000, backgroundMs: 15000 }, true),
+		);
+
+		await waitFor(() => {
+			expect(result.current.worktreeChanges.get('wt-1')?.changedFileCount).toBe(1);
+		});
+
+		// Failing worktree should not crash hook or remove other entries
+		expect(result.current.worktreeChanges.get('wt-2')).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary
- add useMultiWorktreeStatus hook to poll git status across worktrees with fast active/background intervals
- surface per-worktree change counts and live status in App while keeping git markers in sync
- add hook coverage and force consistent git status glyphs in TreeNode tests

## Testing
- npm test

Closes #143