### PR TITLE
feat: add CopyTree profile support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -318,7 +318,7 @@ const AppContent: React.FC<AppProps> = ({ cwd, config: initialConfig, noWatch, n
   }, [projectIdentity]);
 
   // Centralized CopyTree listener (survives StatusBar unmount/hide)
-  useCopyTree(activeRootPath);
+  useCopyTree(activeRootPath, effectiveConfig);
 
   useWatcher(activeRootPath, effectiveConfig, !!noWatch);
 

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -13,6 +13,8 @@ export interface ModalContextMap {
 // 1. Define Payload Types
 export interface CopyTreePayload {
   rootPath?: string;
+  profile?: string;
+  extraArgs?: string[];
 }
 
 export interface CopyPathPayload {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,11 @@ export type FileType = 'file' | 'directory';
 
 export type NotificationType = 'info' | 'success' | 'error' | 'warning';
 
+export interface CopytreeProfile {
+  args: string[];
+  description?: string;
+}
+
 export interface WorktreeChanges {
   worktreeId: string;
   rootPath: string;
@@ -133,6 +138,7 @@ export interface CanopyConfig {
     format: string;
     asReference: boolean;
   };
+  copytreeProfiles?: Record<string, CopytreeProfile>;
   openers?: OpenersConfig;
   autoRefresh: boolean;
   refreshDebounce: number;
@@ -232,6 +238,24 @@ export const DEFAULT_CONFIG: CanopyConfig = {
     enable: true,              // Enabled by default for backwards compatibility
     showInHeader: true,        // Show indicator by default
     refreshIntervalMs: 10000,  // 10 second refresh by default
+  },
+  copytreeProfiles: {
+    default: {
+      args: ['-r'],
+      description: 'Standard recursive scan (uses .copytree.yml if present)'
+    },
+    minimal: {
+      args: ['--tree-only', '--depth', '2'],
+      description: 'Structure only, max depth 2'
+    },
+    debug: {
+      args: ['--verbose', '--no-cache'],
+      description: 'Verbose output with cache disabled'
+    },
+    docs: {
+      args: ['-p', 'docs'],
+      description: 'Documentation only'
+    }
   },
   recentActivity: {
     enabled: true,             // Enabled by default

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -165,6 +165,19 @@ function mergeConfigs(...configs: Partial<CanopyConfig>[]): CanopyConfig {
       }
 
       if (
+        typedKey === 'copytreeProfiles' &&
+        value &&
+        typeof value === 'object' &&
+        !Array.isArray(value)
+      ) {
+        merged[typedKey] = {
+          ...(merged.copytreeProfiles || {}),
+          ...(value as Record<string, unknown>),
+        } as typeof merged.copytreeProfiles;
+        continue;
+      }
+
+      if (
         typedKey === 'openers' &&
         value &&
         typeof value === 'object' &&
@@ -301,6 +314,33 @@ function validateConfig(config: unknown): CanopyConfig {
     }
     if (typeof c.copytreeDefaults.asReference !== 'boolean') {
       errors.push('config.copytreeDefaults.asReference must be a boolean');
+    }
+  }
+
+  if (c.copytreeProfiles !== undefined) {
+    if (!c.copytreeProfiles || typeof c.copytreeProfiles !== 'object' || Array.isArray(c.copytreeProfiles)) {
+      errors.push('config.copytreeProfiles must be an object');
+    } else {
+      for (const [profileName, profile] of Object.entries(c.copytreeProfiles)) {
+        if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
+          errors.push(`config.copytreeProfiles.${profileName} must be an object`);
+          continue;
+        }
+
+        if (!Array.isArray((profile as any).args)) {
+          errors.push(`config.copytreeProfiles.${profileName}.args must be an array of strings`);
+        } else {
+          for (let i = 0; i < (profile as any).args.length; i++) {
+            if (typeof (profile as any).args[i] !== 'string') {
+              errors.push(`config.copytreeProfiles.${profileName}.args[${i}] must be a string`);
+            }
+          }
+        }
+
+        if ((profile as any).description !== undefined && typeof (profile as any).description !== 'string') {
+          errors.push(`config.copytreeProfiles.${profileName}.description must be a string if provided`);
+        }
+      }
     }
   }
 

--- a/src/utils/contextMenuActions.ts
+++ b/src/utils/contextMenuActions.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import { execa } from 'execa';
-import { runCopyTree } from './copytree.js';
 import { copyFilePath, copyToClipboard } from './clipboard.js';
 import { openFile } from './fileOpener.js';
 import type { ContextMenuItem } from '../types/contextMenu.js';

--- a/src/utils/copytree.ts
+++ b/src/utils/copytree.ts
@@ -1,22 +1,67 @@
 import { execa } from 'execa';
+import type { CanopyConfig } from '../types/index.js';
+import { logWarn } from './logger.js';
 
-/**
- * Executes the 'copytree' command in the specified directory.
- * 
- * @param cwd The current working directory to run the command in (usually activeRootPath)
- * @returns The stdout output from the command
- * @throws Error if command fails or is not found
- */
-export async function runCopyTree(cwd: string): Promise<string> {
+const FALLBACK_ARGS = ['-r'];
+
+function resolveProfileArgs(profileName: string, config: CanopyConfig): string[] {
+  const profiles = config.copytreeProfiles || {};
+
+  if (profiles[profileName]) {
+    return profiles[profileName].args;
+  }
+
+  if (profiles.default) {
+    logWarn('CopyTree profile not found, falling back to default', {
+      requestedProfile: profileName,
+    });
+    return profiles.default.args;
+  }
+
+  logWarn('No CopyTree profiles defined, using fallback args', { requestedProfile: profileName });
+  return FALLBACK_ARGS;
+}
+
+async function executeCopyTree(cwd: string, args: string[]): Promise<string> {
   try {
-    // Using -r flag as per spec
-    const { stdout } = await execa('copytree', ['-r'], { cwd });
+    const { stdout } = await execa('copytree', args, { cwd });
     return stdout.trim();
   } catch (error: any) {
-    // Improve error message if command is missing
     if (error.code === 'ENOENT') {
       throw new Error('copytree command not found. Please install it first.');
     }
     throw new Error(error.message || 'CopyTree execution failed');
   }
+}
+
+/**
+ * Executes the 'copytree' command using a named profile merged with optional extra args.
+ *
+ * @param cwd - Directory to run the command in (usually activeRootPath)
+ * @param profileName - Profile key to resolve from configuration
+ * @param config - Resolved Canopy configuration containing copytreeProfiles
+ * @param extraArgs - Optional additional flags to append
+ */
+export async function runCopyTreeWithProfile(
+  cwd: string,
+  profileName: string,
+  config: CanopyConfig,
+  extraArgs: string[] = []
+): Promise<string> {
+  const baseArgs = resolveProfileArgs(profileName, config);
+  const args = [...baseArgs, ...extraArgs];
+  return executeCopyTree(cwd, args);
+}
+
+/**
+ * Backwards-compatible wrapper that executes CopyTree with the provided profile
+ * (defaults to "default").
+ */
+export async function runCopyTree(
+  cwd: string,
+  config: CanopyConfig,
+  profileName = 'default',
+  extraArgs: string[] = []
+): Promise<string> {
+  return runCopyTreeWithProfile(cwd, profileName, config, extraArgs);
 }

--- a/tests/App.integration.test.tsx
+++ b/tests/App.integration.test.tsx
@@ -22,13 +22,13 @@ vi.mock('../src/utils/worktree.js', () => ({
 vi.mock('../src/utils/config.js');
 
 vi.mock('../src/utils/copytree.js', () => ({
-  runCopyTree: vi.fn().mockResolvedValue('Success\nCopied!'),
+  runCopyTreeWithProfile: vi.fn().mockResolvedValue('Success\nCopied!'),
 }));
 
 import { openFile } from '../src/utils/fileOpener.js';
 import { copyFilePath } from '../src/utils/clipboard.js';
 import * as configUtils from '../src/utils/config.js';
-import { runCopyTree } from '../src/utils/copytree.js';
+import { runCopyTreeWithProfile } from '../src/utils/copytree.js';
 import { events } from '../src/services/events.js';
 import { getWorktrees, getCurrentWorktree } from '../src/utils/worktree.js';
 
@@ -137,7 +137,7 @@ describe('App integration - CopyTree centralized listener', () => {
     await waitForCondition(() => !lastFrame()?.includes('Loading Canopy'));
 
     // Clear any previous calls
-    vi.mocked(runCopyTree).mockClear();
+    vi.mocked(runCopyTreeWithProfile).mockClear();
 
     // Create a promise to wait for notification
     let notificationReceived = false;
@@ -151,10 +151,15 @@ describe('App integration - CopyTree centralized listener', () => {
     events.emit('file:copy-tree', {});
 
     // Wait for runCopyTree to be called
-    await waitForCondition(() => vi.mocked(runCopyTree).mock.calls.length > 0);
+    await waitForCondition(() => vi.mocked(runCopyTreeWithProfile).mock.calls.length > 0);
 
     // Verify runCopyTree was called with the correct path
-    expect(runCopyTree).toHaveBeenCalledWith('/test/project');
+    expect(runCopyTreeWithProfile).toHaveBeenCalledWith(
+      '/test/project',
+      'default',
+      expect.any(Object),
+      []
+    );
 
     // Wait for notification
     await waitForCondition(() => notificationReceived);
@@ -169,21 +174,26 @@ describe('App integration - CopyTree centralized listener', () => {
     await waitForCondition(() => !lastFrame()?.includes('Loading Canopy'));
 
     // Clear any previous calls
-    vi.mocked(runCopyTree).mockClear();
+    vi.mocked(runCopyTreeWithProfile).mockClear();
 
     // Emit file:copy-tree event with custom path
     events.emit('file:copy-tree', { rootPath: '/custom/path' });
 
     // Wait for runCopyTree to be called
-    await waitForCondition(() => vi.mocked(runCopyTree).mock.calls.length > 0);
+    await waitForCondition(() => vi.mocked(runCopyTreeWithProfile).mock.calls.length > 0);
 
     // Verify runCopyTree was called with the custom path
-    expect(runCopyTree).toHaveBeenCalledWith('/custom/path');
+    expect(runCopyTreeWithProfile).toHaveBeenCalledWith(
+      '/custom/path',
+      'default',
+      expect.any(Object),
+      []
+    );
   });
 
   it('emits error notification when CopyTree fails', async () => {
     // Mock failure
-    vi.mocked(runCopyTree).mockRejectedValueOnce(new Error('CopyTree command failed'));
+    vi.mocked(runCopyTreeWithProfile).mockRejectedValueOnce(new Error('CopyTree command failed'));
 
     const { lastFrame } = render(<App cwd="/test/project" />);
 

--- a/tests/utils/config.test.ts
+++ b/tests/utils/config.test.ts
@@ -294,6 +294,33 @@ describe('loadConfig', () => {
     // Missing field should be filled from defaults
     expect(config.copytreeDefaults).toEqual(DEFAULT_CONFIG.copytreeDefaults);
   });
+
+  it('validates copytreeProfiles entries', async () => {
+    const invalidConfig = {
+      copytreeProfiles: {
+        bad: { args: '--flag' as any },
+      },
+    };
+    await fs.writeJSON(path.join(tempDir, '.canopy.json'), invalidConfig);
+
+    await expect(loadConfig(tempDir)).rejects.toThrow('copytreeProfiles.bad.args must be an array of strings');
+  });
+
+  it('merges copytreeProfiles with defaults', async () => {
+    const projectConfig = {
+      copytreeProfiles: {
+        default: { args: ['--custom-default'] },
+        quick: { args: ['--depth', '1'] },
+      },
+    };
+    await fs.writeJSON(path.join(tempDir, '.canopy.json'), projectConfig);
+
+    const config = await loadConfig(tempDir);
+
+    expect(config.copytreeProfiles?.default.args).toEqual(['--custom-default']);
+    expect(config.copytreeProfiles?.quick.args).toEqual(['--depth', '1']);
+    expect(config.copytreeProfiles?.minimal).toBeDefined();
+  });
 });
 
 // Global config tests

--- a/tests/utils/copytree.test.ts
+++ b/tests/utils/copytree.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('execa', () => ({
+  execa: vi.fn(),
+}));
+
+vi.mock('../../src/utils/logger.js', () => ({
+  logWarn: vi.fn(),
+}));
+
+import { runCopyTreeWithProfile, runCopyTree } from '../../src/utils/copytree.js';
+import { DEFAULT_CONFIG } from '../../src/types/index.js';
+import { execa as mockedExeca } from 'execa';
+import { logWarn } from '../../src/utils/logger.js';
+
+describe('copytree utility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('runs copytree with a named profile', async () => {
+    mockedExeca.mockResolvedValue({ stdout: 'ok' } as any);
+    const config = {
+      ...DEFAULT_CONFIG,
+      copytreeProfiles: {
+        ...DEFAULT_CONFIG.copytreeProfiles,
+        minimal: { args: ['--tree-only'], description: 'structure only' },
+      },
+    };
+
+    const output = await runCopyTreeWithProfile('/repo', 'minimal', config);
+
+    expect(output).toBe('ok');
+    expect(mockedExeca).toHaveBeenCalledWith('copytree', ['--tree-only'], { cwd: '/repo' });
+  });
+
+  it('falls back to default profile when requested profile is missing', async () => {
+    mockedExeca.mockResolvedValue({ stdout: 'done' } as any);
+
+    await runCopyTreeWithProfile('/repo', 'unknown', DEFAULT_CONFIG);
+
+    expect(mockedExeca).toHaveBeenCalledWith(
+      'copytree',
+      DEFAULT_CONFIG.copytreeProfiles!.default.args,
+      { cwd: '/repo' }
+    );
+    expect(vi.mocked(logWarn)).toHaveBeenCalled();
+  });
+
+  it('falls back to built-in args when profiles are undefined', async () => {
+    mockedExeca.mockResolvedValue({ stdout: 'done' } as any);
+    const config = { ...DEFAULT_CONFIG, copytreeProfiles: undefined };
+
+    await runCopyTreeWithProfile('/repo', 'default', config);
+
+    expect(mockedExeca).toHaveBeenCalledWith('copytree', ['-r'], { cwd: '/repo' });
+    expect(vi.mocked(logWarn)).toHaveBeenCalled();
+  });
+
+  it('appends extra args after profile args', async () => {
+    mockedExeca.mockResolvedValue({ stdout: 'done' } as any);
+
+    await runCopyTreeWithProfile('/repo', 'debug', DEFAULT_CONFIG, ['--foo']);
+
+    expect(mockedExeca).toHaveBeenCalledWith(
+      'copytree',
+      [...(DEFAULT_CONFIG.copytreeProfiles?.debug.args ?? []), '--foo'],
+      { cwd: '/repo' }
+    );
+  });
+
+  it('runCopyTree delegates to the default profile', async () => {
+    mockedExeca.mockResolvedValue({ stdout: 'ok' } as any);
+
+    await runCopyTree('/repo', DEFAULT_CONFIG);
+
+    expect(mockedExeca).toHaveBeenCalledWith(
+      'copytree',
+      DEFAULT_CONFIG.copytreeProfiles!.default.args,
+      { cwd: '/repo' }
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add configurable CopyTree profiles with defaults (default/minimal/debug/docs) and validation
- Resolve profiles when running CopyTree and allow payload profile/extraArgs handling
- Update CopyTree hook/tests to pass config and profile args; add profile resolution coverage

## Testing
- npm test

Closes #145