### PR TITLE
feat: add WorktreeCard component

### DIFF
--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -13,6 +13,7 @@ Authoritative checklist for handling a single GitHub issue end-to-end.
 5. **Implement and verify**  
    - Make the changes, keep the worktree clean, and ensure the full test suite (`npm test`, etc.) passes locally.
 6. **Open and merge a PR**  
-   - Push the branch, open a PR with a clear summary and testing notes, then merge immediately once checks pass. Delete the feature branch after merge.
+   - Push the branch, open a PR that explicitly references and closes the issue (e.g., `Closes #123`), includes a concise implementation summary and testing notes, then merge immediately once checks pass. Delete the feature branch after merge.
+   - Keep PR bodies readable: use real newlines/bullets (no escaped `\n` strings), list key changes and tests run.
 
 Use this workflow as the source of truth for future issue handling.***

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -728,7 +728,11 @@ const AppContent: React.FC<AppProps> = ({ cwd, config: initialConfig, noWatch, n
       }
 
       const currentIndex = worktreeList.findIndex(wt => wt.id === activeWorktreeId);
-      const nextIndex = (currentIndex + direction + worktreeList.length) % worktreeList.length;
+      const fallbackIndex = worktreeList.findIndex(wt => wt.isCurrent);
+      const resolvedIndex = currentIndex >= 0
+        ? currentIndex
+        : (fallbackIndex >= 0 ? fallbackIndex : 0);
+      const nextIndex = (resolvedIndex + direction + worktreeList.length) % worktreeList.length;
       const nextWorktree = worktreeList[nextIndex];
 
       await handleSwitchWorktree(nextWorktree);
@@ -748,7 +752,11 @@ const AppContent: React.FC<AppProps> = ({ cwd, config: initialConfig, noWatch, n
 
     const worktreeList = worktreesWithStatus;
     const currentIndex = worktreeList.findIndex(wt => wt.id === activeWorktreeId);
-    const nextIndex = (currentIndex + direction + worktreeList.length) % worktreeList.length;
+    const fallbackIndex = worktreeList.findIndex(wt => wt.isCurrent);
+    const resolvedIndex = currentIndex >= 0
+      ? currentIndex
+      : (fallbackIndex >= 0 ? fallbackIndex : 0);
+    const nextIndex = (resolvedIndex + direction + worktreeList.length) % worktreeList.length;
     const nextWorktree = worktreeList[nextIndex];
 
     if (nextWorktree) {

--- a/src/components/WorktreeCard.tsx
+++ b/src/components/WorktreeCard.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import type { Worktree, WorktreeChanges, WorktreeMood } from '../types/index.js';
+import { GitIndicator } from '../utils/gitIndicators.js';
+import { useTheme } from '../theme/ThemeProvider.js';
+import { getBorderColorForMood } from '../utils/moodColors.js';
+
+export interface WorktreeCardProps {
+  worktree: Worktree;
+  changes: WorktreeChanges;
+  mood: WorktreeMood;
+  isFocused: boolean;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+}
+
+const MAX_VISIBLE_CHANGES = 10;
+
+export const WorktreeCard: React.FC<WorktreeCardProps> = ({
+  worktree,
+  changes,
+  mood,
+  isFocused,
+  isExpanded,
+  onToggleExpand,
+}) => {
+  const { palette } = useTheme();
+
+  const borderColor = getBorderColorForMood(mood);
+  const borderStyle = isFocused ? 'double' : 'round';
+  const headerColor = mood === 'active' ? palette.git.modified : palette.text.primary;
+  const visibleChanges = isExpanded ? changes.changes.slice(0, MAX_VISIBLE_CHANGES) : [];
+  const remainingCount = isExpanded
+    ? Math.max(0, changes.changes.length - visibleChanges.length)
+    : 0;
+
+  const fileCountLabel =
+    changes.changedFileCount === 1
+      ? '1 file'
+      : `${changes.changedFileCount} files`;
+
+  const summaryText = worktree.summary ?? 'No summary yet';
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle={borderStyle}
+      borderColor={borderColor}
+      paddingX={1}
+      paddingY={1}
+      marginBottom={1}
+    >
+      <Box flexDirection="column">
+        <Box>
+          <Text bold color={headerColor}>
+            {worktree.branch ?? worktree.name}
+          </Text>
+          {!worktree.branch && (
+            <Text color={palette.alert.warning}> (detached)</Text>
+          )}
+        </Box>
+
+        <Box justifyContent="space-between">
+          <Text color={palette.text.secondary} dimColor={!worktree.summary}>
+            {summaryText}
+          </Text>
+          <Text color={palette.text.tertiary}>{fileCountLabel}</Text>
+        </Box>
+      </Box>
+
+      {isExpanded && (
+        <Box flexDirection="column" marginTop={1}>
+          {visibleChanges.map(change => (
+            <Box key={`${change.path}-${change.status}`}>
+              <GitIndicator status={change.status} />
+              <Text> {change.path}</Text>
+            </Box>
+          ))}
+          {remainingCount > 0 && (
+            <Text dimColor>...and {remainingCount} more</Text>
+          )}
+        </Box>
+      )}
+
+      {isFocused && (
+        <Box marginTop={1}>
+          <Text dimColor>
+            <Text color={palette.accent.primary}>[c]</Text> CopyTree{'  '}
+            <Text color={palette.accent.primary}>[p]</Text> Profile{'  '}
+            <Text color={palette.accent.primary}>[Enter]</Text> VS Code
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/src/utils/moodColors.ts
+++ b/src/utils/moodColors.ts
@@ -1,0 +1,15 @@
+import type { WorktreeMood } from '../types/index.js';
+
+const BORDER_COLORS: Record<WorktreeMood, string> = {
+  stable: 'green',
+  active: 'yellow',
+  error: 'red',
+  stale: 'gray',
+};
+
+/**
+ * Map a worktree mood to a border color string for Ink components.
+ */
+export function getBorderColorForMood(mood: WorktreeMood): string {
+  return BORDER_COLORS[mood];
+}

--- a/tests/components/WorktreeCard.test.tsx
+++ b/tests/components/WorktreeCard.test.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { describe, expect, it, vi } from 'vitest';
+import { WorktreeCard } from '../../src/components/WorktreeCard.js';
+import type { Worktree, WorktreeChanges } from '../../src/types/index.js';
+import { ThemeProvider } from '../../src/theme/ThemeProvider.js';
+import { getBorderColorForMood } from '../../src/utils/moodColors.js';
+import * as moodColors from '../../src/utils/moodColors.js';
+
+const renderWithTheme = (component: React.ReactElement) =>
+  render(<ThemeProvider mode="dark">{component}</ThemeProvider>);
+
+const baseWorktree: Worktree = {
+  id: 'wt-1',
+  path: '/repo/main',
+  name: 'main',
+  branch: 'main',
+  isCurrent: true,
+  summary: 'Refining dashboard layout',
+};
+
+const baseChanges: WorktreeChanges = {
+  worktreeId: 'wt-1',
+  rootPath: '/repo/main',
+  changes: [
+    { path: 'src/index.ts', status: 'modified' },
+    { path: 'README.md', status: 'added' },
+  ],
+  changedFileCount: 2,
+  lastUpdated: Date.now(),
+};
+
+describe('WorktreeCard', () => {
+  it('maps moods to border colors', () => {
+    expect(getBorderColorForMood('active')).toBe('yellow');
+    expect(getBorderColorForMood('stable')).toBe('green');
+  });
+
+  it('renders summary and file count in the header', () => {
+    const { lastFrame } = renderWithTheme(
+      <WorktreeCard
+        worktree={baseWorktree}
+        changes={baseChanges}
+        mood="stable"
+        isFocused={false}
+        isExpanded={false}
+        onToggleExpand={vi.fn()}
+      />,
+    );
+
+    const output = lastFrame();
+    expect(output).toContain('Refining dashboard layout');
+    expect(output).toContain('2 files');
+  });
+
+  it('shows change list when expanded', () => {
+    const { lastFrame } = renderWithTheme(
+      <WorktreeCard
+        worktree={baseWorktree}
+        changes={baseChanges}
+        mood="stable"
+        isFocused={false}
+        isExpanded
+        onToggleExpand={vi.fn()}
+      />,
+    );
+
+    const output = lastFrame();
+    expect(output).toContain('src/index.ts');
+    expect(output).toContain('README.md');
+  });
+
+  it('hides change list when collapsed', () => {
+    const { lastFrame } = renderWithTheme(
+      <WorktreeCard
+        worktree={baseWorktree}
+        changes={baseChanges}
+        mood="stable"
+        isFocused={false}
+        isExpanded={false}
+        onToggleExpand={vi.fn()}
+      />,
+    );
+
+    expect(lastFrame()).not.toContain('src/index.ts');
+  });
+
+  it('shows footer hints only when focused', () => {
+    const { lastFrame, rerender } = renderWithTheme(
+      <WorktreeCard
+        worktree={baseWorktree}
+        changes={baseChanges}
+        mood="stable"
+        isFocused={true}
+        isExpanded={false}
+        onToggleExpand={vi.fn()}
+      />,
+    );
+
+    expect(lastFrame()).toContain('CopyTree');
+
+    rerender(
+      <ThemeProvider mode="dark">
+        <WorktreeCard
+          worktree={baseWorktree}
+          changes={baseChanges}
+          mood="stable"
+          isFocused={false}
+          isExpanded={false}
+          onToggleExpand={vi.fn()}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(lastFrame()).not.toContain('CopyTree');
+  });
+
+  it('limits visible changes and shows overflow indicator', () => {
+    const manyChanges: WorktreeChanges = {
+      ...baseChanges,
+      changes: Array.from({ length: 12 }, (_, index) => ({
+        path: `file-${index}.ts`,
+        status: 'modified' as const,
+      })),
+      changedFileCount: 12,
+    };
+
+    const { lastFrame } = renderWithTheme(
+      <WorktreeCard
+        worktree={baseWorktree}
+        changes={manyChanges}
+        mood="active"
+        isFocused={false}
+        isExpanded
+        onToggleExpand={vi.fn()}
+      />,
+    );
+
+    const output = lastFrame();
+    expect(output).toContain('file-0.ts');
+    expect(output).not.toContain('file-11.ts');
+    expect(output).toContain('...and 2 more');
+  });
+
+  it('uses mood color helper for border rendering', () => {
+    const spy = vi.spyOn(moodColors, 'getBorderColorForMood');
+    renderWithTheme(
+      <WorktreeCard
+        worktree={baseWorktree}
+        changes={baseChanges}
+        mood="error"
+        isFocused={false}
+        isExpanded={false}
+        onToggleExpand={vi.fn()}
+      />,
+    );
+
+    expect(spy).toHaveBeenCalledWith('error');
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
Closes #146

## Summary
- add mood color mapping helper for worktree moods
- build WorktreeCard presentation with expandable change list and focus/footer cues
- harden worktree cycling by falling back to the current worktree when the active id is missing

## Testing
- npm test