### PR TITLE
Add worktree overview dashboard

### DIFF
--- a/src/components/WorktreeCard.tsx
+++ b/src/components/WorktreeCard.tsx
@@ -12,6 +12,8 @@ export interface WorktreeCardProps {
   isFocused: boolean;
   isExpanded: boolean;
   onToggleExpand: () => void;
+  onCopyTree?: () => void;
+  onOpenEditor?: () => void;
 }
 
 const MAX_VISIBLE_CHANGES = 10;
@@ -23,8 +25,13 @@ export const WorktreeCard: React.FC<WorktreeCardProps> = ({
   isFocused,
   isExpanded,
   onToggleExpand,
+  onCopyTree,
+  onOpenEditor,
 }) => {
   const { palette } = useTheme();
+  const showCopyTreeHint = Boolean(onCopyTree);
+  const showOpenEditorHint = Boolean(onOpenEditor);
+  const hasToggleHandler = typeof onToggleExpand === 'function';
 
   const borderColor = getBorderColorForMood(mood);
   const borderStyle = isFocused ? 'double' : 'round';
@@ -85,9 +92,22 @@ export const WorktreeCard: React.FC<WorktreeCardProps> = ({
       {isFocused && (
         <Box marginTop={1}>
           <Text dimColor>
-            <Text color={palette.accent.primary}>[c]</Text> CopyTree{'  '}
+            {hasToggleHandler && (
+              <>
+                <Text color={palette.accent.primary}>[space]</Text> Expand{'  '}
+              </>
+            )}
+            {showCopyTreeHint && (
+              <>
+                <Text color={palette.accent.primary}>[c]</Text> CopyTree{'  '}
+              </>
+            )}
             <Text color={palette.accent.primary}>[p]</Text> Profile{'  '}
-            <Text color={palette.accent.primary}>[Enter]</Text> VS Code
+            {showOpenEditorHint && (
+              <>
+                <Text color={palette.accent.primary}>[Enter]</Text> VS Code
+              </>
+            )}
           </Text>
         </Box>
       )}

--- a/src/components/WorktreeOverview.tsx
+++ b/src/components/WorktreeOverview.tsx
@@ -1,0 +1,100 @@
+import React, { useMemo } from 'react';
+import { Box } from 'ink';
+import type { Worktree, WorktreeChanges, WorktreeMood } from '../types/index.js';
+import { WorktreeCard } from './WorktreeCard.js';
+
+export interface WorktreeOverviewProps {
+  worktrees: Worktree[];
+  worktreeChanges: Map<string, WorktreeChanges>;
+  activeWorktreeId: string | null;
+  focusedWorktreeId: string | null;
+  expandedWorktreeIds: Set<string>;
+  onToggleExpand: (id: string) => void;
+  onCopyTree: (id: string, profile?: string) => void;
+  onOpenEditor: (id: string) => void;
+}
+
+const MOOD_PRIORITY: Record<WorktreeMood, number> = {
+  active: 1,
+  stable: 2,
+  stale: 3,
+  error: 4,
+};
+
+const FALLBACK_CHANGES: WorktreeChanges = {
+  worktreeId: '',
+  rootPath: '',
+  changes: [],
+  changedFileCount: 0,
+  lastUpdated: 0,
+};
+
+export function sortWorktrees(worktrees: Worktree[]): Worktree[] {
+  if (worktrees.length === 0) {
+    return [];
+  }
+
+  const mainIndex = worktrees.findIndex(
+    wt => wt.branch === 'main' || wt.branch === 'master'
+  );
+
+  const sorted = [...worktrees].sort((a, b) => {
+    const priorityA = MOOD_PRIORITY[a.mood ?? 'stable'] ?? 5;
+    const priorityB = MOOD_PRIORITY[b.mood ?? 'stable'] ?? 5;
+
+    if (priorityA !== priorityB) {
+      return priorityA - priorityB;
+    }
+
+    const labelA = a.branch || a.name;
+    const labelB = b.branch || b.name;
+    return labelA.localeCompare(labelB);
+  });
+
+  if (mainIndex >= 0) {
+    const mainWorktree = worktrees[mainIndex];
+    const filtered = sorted.filter(wt => wt !== mainWorktree);
+    return [mainWorktree, ...filtered];
+  }
+
+  return sorted;
+}
+
+export const WorktreeOverview: React.FC<WorktreeOverviewProps> = ({
+  worktrees,
+  worktreeChanges,
+  focusedWorktreeId,
+  expandedWorktreeIds,
+  onToggleExpand,
+  onCopyTree,
+  onOpenEditor,
+}) => {
+  const sorted = useMemo(() => sortWorktrees(worktrees), [worktrees]);
+
+  return (
+    <Box flexDirection="column" gap={1} flexGrow={1}>
+      {sorted.map((worktree) => {
+        const changes = worktreeChanges.get(worktree.id) ?? {
+          ...FALLBACK_CHANGES,
+          worktreeId: worktree.id,
+          rootPath: worktree.path,
+        };
+
+        return (
+          <WorktreeCard
+            key={worktree.id}
+            worktree={worktree}
+            changes={changes}
+            mood={worktree.mood ?? 'stable'}
+            isFocused={worktree.id === focusedWorktreeId}
+            isExpanded={expandedWorktreeIds.has(worktree.id)}
+            onToggleExpand={() => onToggleExpand(worktree.id)}
+            // Future interactive actions
+            onCopyTree={() => onCopyTree(worktree.id)}
+            onOpenEditor={() => onOpenEditor(worktree.id)}
+          />
+        );
+      })}
+    </Box>
+  );
+};

--- a/src/hooks/useFileTree.ts
+++ b/src/hooks/useFileTree.ts
@@ -24,6 +24,7 @@ export interface UseFileTreeOptions {
   initialSelectedPath?: string | null;
   initialExpandedFolders?: Set<string>;
   viewportHeight: number; // Added
+  navigationEnabled?: boolean;
 }
 
 export interface UseFileTreeResult {
@@ -49,7 +50,17 @@ export interface UseFileTreeResult {
  * @returns Tree state and actions
  */
 export function useFileTree(options: UseFileTreeOptions): UseFileTreeResult {
-  const { rootPath, config, filterQuery, gitStatusMap, gitStatusFilter, initialSelectedPath, initialExpandedFolders, viewportHeight } = options;
+  const {
+    rootPath,
+    config,
+    filterQuery,
+    gitStatusMap,
+    gitStatusFilter,
+    initialSelectedPath,
+    initialExpandedFolders,
+    viewportHeight,
+    navigationEnabled = true,
+  } = options;
 
   // Internal State
   const [tree, setTree] = useState<TreeNode[]>([]);
@@ -291,6 +302,10 @@ export function useFileTree(options: UseFileTreeOptions): UseFileTreeResult {
 
   // --- Event Listeners for Navigation, Selection, Expansion ---
   useEffect(() => {
+    if (!navigationEnabled) {
+      return undefined;
+    }
+
     const unsubscribes = [
       events.on('nav:select', (payload) => {
         selectPath(payload.path);
@@ -383,7 +398,7 @@ export function useFileTree(options: UseFileTreeOptions): UseFileTreeResult {
     return () => {
       unsubscribes.forEach(unsub => unsub());
     };
-  }, [flattenedTree, selectedPath, expandedFolders, viewportHeight]);
+  }, [flattenedTree, selectedPath, expandedFolders, viewportHeight, navigationEnabled]);
 
   // --- Event Listener for Refresh ---
   useEffect(() => {

--- a/tests/components/WorktreeCard.test.tsx
+++ b/tests/components/WorktreeCard.test.tsx
@@ -45,6 +45,8 @@ describe('WorktreeCard', () => {
         isFocused={false}
         isExpanded={false}
         onToggleExpand={vi.fn()}
+        onCopyTree={vi.fn()}
+        onOpenEditor={vi.fn()}
       />,
     );
 
@@ -62,6 +64,8 @@ describe('WorktreeCard', () => {
         isFocused={false}
         isExpanded
         onToggleExpand={vi.fn()}
+        onCopyTree={vi.fn()}
+        onOpenEditor={vi.fn()}
       />,
     );
 
@@ -79,6 +83,8 @@ describe('WorktreeCard', () => {
         isFocused={false}
         isExpanded={false}
         onToggleExpand={vi.fn()}
+        onCopyTree={vi.fn()}
+        onOpenEditor={vi.fn()}
       />,
     );
 
@@ -94,6 +100,8 @@ describe('WorktreeCard', () => {
         isFocused={true}
         isExpanded={false}
         onToggleExpand={vi.fn()}
+        onCopyTree={vi.fn()}
+        onOpenEditor={vi.fn()}
       />,
     );
 
@@ -108,6 +116,8 @@ describe('WorktreeCard', () => {
           isFocused={false}
           isExpanded={false}
           onToggleExpand={vi.fn()}
+          onCopyTree={vi.fn()}
+          onOpenEditor={vi.fn()}
         />
       </ThemeProvider>,
     );
@@ -133,6 +143,8 @@ describe('WorktreeCard', () => {
         isFocused={false}
         isExpanded
         onToggleExpand={vi.fn()}
+        onCopyTree={vi.fn()}
+        onOpenEditor={vi.fn()}
       />,
     );
 
@@ -152,6 +164,8 @@ describe('WorktreeCard', () => {
         isFocused={false}
         isExpanded={false}
         onToggleExpand={vi.fn()}
+        onCopyTree={vi.fn()}
+        onOpenEditor={vi.fn()}
       />,
     );
 

--- a/tests/components/WorktreeOverview.test.tsx
+++ b/tests/components/WorktreeOverview.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Box } from 'ink';
+import { render } from 'ink-testing-library';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { Worktree, WorktreeChanges } from '../../src/types/index.js';
+
+const capturedProps: any[] = [];
+
+vi.mock('../../src/components/WorktreeCard.js', () => ({
+  WorktreeCard: (props: any) => {
+    capturedProps.push(props);
+    return <Box>{props.worktree.branch || props.worktree.name}</Box>;
+  },
+}));
+
+import { WorktreeOverview, sortWorktrees } from '../../src/components/WorktreeOverview.js';
+
+const makeChanges = (id: string): WorktreeChanges => ({
+  worktreeId: id,
+  rootPath: `/repo/${id}`,
+  changes: [],
+  changedFileCount: 0,
+  lastUpdated: Date.now(),
+});
+
+describe('WorktreeOverview', () => {
+  beforeEach(() => {
+    capturedProps.length = 0;
+  });
+
+  it('sorts main first then by mood priority', () => {
+    const worktrees: Worktree[] = [
+      { id: 'feature', path: '/repo/feature', name: 'feature', branch: 'feature', isCurrent: false, mood: 'active' },
+      { id: 'main', path: '/repo/main', name: 'main', branch: 'main', isCurrent: true, mood: 'stable' },
+      { id: 'bugfix', path: '/repo/bugfix', name: 'bugfix', branch: 'bugfix', isCurrent: false, mood: 'stale' },
+    ];
+
+    const sorted = sortWorktrees(worktrees);
+    expect(sorted[0].id).toBe('main');
+    expect(sorted[1].id).toBe('feature');
+    expect(sorted[2].id).toBe('bugfix');
+  });
+
+  it('forwards expand handler with correct id', () => {
+    const toggleSpy = vi.fn();
+    const worktrees: Worktree[] = [
+      { id: 'alpha', path: '/repo/alpha', name: 'alpha', branch: 'alpha', isCurrent: true, mood: 'stable' },
+    ];
+    const changes = new Map<string, WorktreeChanges>([['alpha', makeChanges('alpha')]]);
+
+    render(
+      <WorktreeOverview
+        worktrees={worktrees}
+        worktreeChanges={changes}
+        activeWorktreeId="alpha"
+        focusedWorktreeId="alpha"
+        expandedWorktreeIds={new Set()}
+        onToggleExpand={toggleSpy}
+        onCopyTree={vi.fn()}
+        onOpenEditor={vi.fn()}
+      />
+    );
+
+    expect(capturedProps[0]).toBeDefined();
+    capturedProps[0].onToggleExpand();
+    expect(toggleSpy).toHaveBeenCalledWith('alpha');
+  });
+});


### PR DESCRIPTION
Adding Worktree dashboard overview.

- Closes #147.
- Added WorktreeOverview that pins main, sorts by mood, and renders WorktreeCards with fallback change data.
- Added dashboard focus/expand state with keyboard handling, copy-tree/editor shortcuts, and integrated CopyTree payloads.
- Disabled file-tree navigation listeners to keep dashboard keys isolated and added WorktreeOverview + card coverage.
- Tests: npm test.