### PR TITLE
feat: add dashboard navigation hook

### DIFF
--- a/src/components/WorktreeOverview.tsx
+++ b/src/components/WorktreeOverview.tsx
@@ -9,6 +9,8 @@ export interface WorktreeOverviewProps {
   activeWorktreeId: string | null;
   focusedWorktreeId: string | null;
   expandedWorktreeIds: Set<string>;
+  visibleStart?: number;
+  visibleEnd?: number;
   onToggleExpand: (id: string) => void;
   onCopyTree: (id: string, profile?: string) => void;
   onOpenEditor: (id: string) => void;
@@ -65,15 +67,20 @@ export const WorktreeOverview: React.FC<WorktreeOverviewProps> = ({
   worktreeChanges,
   focusedWorktreeId,
   expandedWorktreeIds,
+  visibleStart,
+  visibleEnd,
   onToggleExpand,
   onCopyTree,
   onOpenEditor,
 }) => {
   const sorted = useMemo(() => sortWorktrees(worktrees), [worktrees]);
+  const start = Math.max(0, visibleStart ?? 0);
+  const end = visibleEnd ?? sorted.length;
+  const sliced = sorted.slice(start, end);
 
   return (
     <Box flexDirection="column" gap={1} flexGrow={1}>
-      {sorted.map((worktree) => {
+      {sliced.map((worktree) => {
         const changes = worktreeChanges.get(worktree.id) ?? {
           ...FALLBACK_CHANGES,
           worktreeId: worktree.id,

--- a/src/hooks/useDashboardNav.ts
+++ b/src/hooks/useDashboardNav.ts
@@ -1,0 +1,204 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useInput } from 'ink';
+import type { Worktree } from '../types/index.js';
+
+export interface DashboardNavProps {
+  worktrees: Worktree[];
+  focusedWorktreeId: string | null;
+  expandedWorktreeIds: Set<string>;
+  isModalOpen: boolean;
+  viewportSize?: number;
+  onFocusChange: (worktreeId: string) => void;
+  onToggleExpand: (worktreeId: string) => void;
+  onCopyTree: (worktreeId: string) => void;
+  onOpenEditor: (worktreeId: string) => void;
+  onOpenProfileSelector: (worktreeId: string) => void;
+}
+
+export interface DashboardNavResult {
+  visibleStart: number;
+  visibleEnd: number;
+}
+
+export function useDashboardNav({
+  worktrees,
+  focusedWorktreeId,
+  expandedWorktreeIds,
+  isModalOpen,
+  viewportSize = 6,
+  onFocusChange,
+  onToggleExpand,
+  onCopyTree,
+  onOpenEditor,
+  onOpenProfileSelector,
+}: DashboardNavProps): DashboardNavResult {
+  const [visibleStart, setVisibleStart] = useState(0);
+
+  const clampedViewport = Math.max(1, viewportSize);
+  const focusedIndex = useMemo(
+    () => worktrees.findIndex(wt => wt.id === focusedWorktreeId),
+    [focusedWorktreeId, worktrees]
+  );
+
+  const ensureVisible = useCallback(
+    (targetIndex: number) => {
+      const maxStart = Math.max(0, worktrees.length - clampedViewport);
+      setVisibleStart(prev => {
+        let nextStart = prev;
+        if (targetIndex < prev) {
+          nextStart = targetIndex;
+        } else if (targetIndex >= prev + clampedViewport) {
+          nextStart = targetIndex - clampedViewport + 1;
+        }
+        return Math.min(Math.max(0, nextStart), maxStart);
+      });
+    },
+    [clampedViewport, worktrees.length]
+  );
+
+  useEffect(() => {
+    if (worktrees.length === 0) {
+      setVisibleStart(0);
+      return;
+    }
+
+    const safeIndex = focusedIndex >= 0 ? focusedIndex : 0;
+    ensureVisible(safeIndex);
+  }, [ensureVisible, focusedIndex, worktrees.length]);
+
+  const resolveFocused = useCallback(() => {
+    if (focusedIndex >= 0) {
+      return { id: focusedWorktreeId, index: focusedIndex };
+    }
+    if (worktrees.length > 0) {
+      return { id: worktrees[0].id, index: 0 };
+    }
+    return { id: null, index: -1 };
+  }, [focusedIndex, focusedWorktreeId, worktrees]);
+
+  const moveFocus = useCallback(
+    (delta: number) => {
+      if (worktrees.length === 0) {
+        return;
+      }
+      const { index } = resolveFocused();
+      const nextIndex = Math.max(0, Math.min(worktrees.length - 1, index + delta));
+      if (nextIndex === index || !worktrees[nextIndex]) {
+        return;
+      }
+      onFocusChange(worktrees[nextIndex].id);
+      ensureVisible(nextIndex);
+    },
+    [ensureVisible, onFocusChange, resolveFocused, worktrees]
+  );
+
+  const focusExact = useCallback(
+    (index: number) => {
+      if (worktrees[index]) {
+        onFocusChange(worktrees[index].id);
+        ensureVisible(index);
+      }
+    },
+    [ensureVisible, onFocusChange, worktrees]
+  );
+
+  const toggleExpansion = useCallback(
+    (id: string, intent: 'toggle' | 'expand' | 'collapse') => {
+      if (intent === 'expand' && expandedWorktreeIds.has(id)) {
+        return;
+      }
+      if (intent === 'collapse' && !expandedWorktreeIds.has(id)) {
+        return;
+      }
+      onToggleExpand(id);
+    },
+    [expandedWorktreeIds, onToggleExpand]
+  );
+
+  const handlePrimaryActions = useCallback(
+    (input: string, key: { return?: boolean; space?: boolean; leftArrow?: boolean; rightArrow?: boolean }) => {
+      const { id, index } = resolveFocused();
+      if (!id || index < 0) {
+        return;
+      }
+
+      if (key.return) {
+        onOpenEditor(id);
+        return;
+      }
+
+      if (input === 'c') {
+        onCopyTree(id);
+        return;
+      }
+
+      if (input === 'p') {
+        onOpenProfileSelector(id);
+        return;
+      }
+
+      if (input === ' ') {
+        toggleExpansion(id, 'toggle');
+        return;
+      }
+
+      if (key.rightArrow) {
+        toggleExpansion(id, 'expand');
+        return;
+      }
+
+      if (key.leftArrow) {
+        toggleExpansion(id, 'collapse');
+      }
+    },
+    [onCopyTree, onOpenEditor, onOpenProfileSelector, resolveFocused, toggleExpansion]
+  );
+
+  useInput(
+    (input, key) => {
+      if (isModalOpen || worktrees.length === 0) {
+        return;
+      }
+
+      if (key.upArrow) {
+        moveFocus(-1);
+        return;
+      }
+
+      if (key.downArrow) {
+        moveFocus(1);
+        return;
+      }
+
+      if (key.pageUp) {
+        moveFocus(-3);
+        return;
+      }
+
+      if (key.pageDown) {
+        moveFocus(3);
+        return;
+      }
+
+      if (key.home) {
+        focusExact(0);
+        return;
+      }
+
+      if (key.end) {
+        focusExact(worktrees.length - 1);
+        return;
+      }
+
+      handlePrimaryActions(input, key);
+    },
+    { isActive: true }
+  );
+
+  const visibleEnd = Math.min(visibleStart + clampedViewport, worktrees.length);
+
+  return {
+    visibleStart,
+    visibleEnd,
+  };
+}

--- a/tests/hooks/useDashboardNav.test.tsx
+++ b/tests/hooks/useDashboardNav.test.tsx
@@ -1,0 +1,156 @@
+import React, { useState } from 'react';
+import { Text } from 'ink';
+import { render } from 'ink-testing-library';
+import { describe, expect, it, vi } from 'vitest';
+import { useDashboardNav } from '../../src/hooks/useDashboardNav.js';
+import type { Worktree } from '../../src/types/index.js';
+
+const worktrees: Worktree[] = [
+  { id: 'main', path: '/repo/main', name: 'main', branch: 'main', isCurrent: true, mood: 'stable' },
+  { id: 'feat', path: '/repo/feat', name: 'feat', branch: 'feat', isCurrent: false, mood: 'active' },
+  { id: 'bug', path: '/repo/bug', name: 'bug', branch: 'bug', isCurrent: false, mood: 'stale' },
+];
+
+const tick = () => new Promise(resolve => setTimeout(resolve, 0));
+
+function Harness({
+  isModalOpen = false,
+  viewportSize = 2,
+  initialExpanded = [] as string[],
+  spies,
+}: {
+  isModalOpen?: boolean;
+  viewportSize?: number;
+  initialExpanded?: string[];
+  spies: {
+    onFocusChange: ReturnType<typeof vi.fn>;
+    onToggleExpand: ReturnType<typeof vi.fn>;
+    onCopyTree: ReturnType<typeof vi.fn>;
+    onOpenEditor: ReturnType<typeof vi.fn>;
+    onOpenProfileSelector: ReturnType<typeof vi.fn>;
+  };
+}) {
+  const [focused, setFocused] = useState<string | null>(worktrees[0].id);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set(initialExpanded));
+
+  const nav = useDashboardNav({
+    worktrees,
+    focusedWorktreeId: focused,
+    expandedWorktreeIds: expanded,
+    isModalOpen,
+    viewportSize,
+    onFocusChange: (id) => {
+      spies.onFocusChange(id);
+      setFocused(id);
+    },
+    onToggleExpand: (id) => {
+      spies.onToggleExpand(id);
+      setExpanded(prev => {
+        const next = new Set(prev);
+        if (next.has(id)) {
+          next.delete(id);
+        } else {
+          next.add(id);
+        }
+        return next;
+      });
+    },
+    onCopyTree: spies.onCopyTree,
+    onOpenEditor: spies.onOpenEditor,
+    onOpenProfileSelector: spies.onOpenProfileSelector,
+  });
+
+  return (
+    <Text>
+      focus:{focused} window:{nav.visibleStart}-{nav.visibleEnd} expanded:{Array.from(expanded).join(',')}
+    </Text>
+  );
+}
+
+describe('useDashboardNav', () => {
+  const makeSpies = () => ({
+    onFocusChange: vi.fn(),
+    onToggleExpand: vi.fn(),
+    onCopyTree: vi.fn(),
+    onOpenEditor: vi.fn(),
+    onOpenProfileSelector: vi.fn(),
+  });
+
+  it('moves focus with arrow keys within bounds', async () => {
+    const spies = makeSpies();
+    const { stdin, lastFrame } = render(<Harness spies={spies} />);
+    await tick();
+
+    stdin.write('\x1B[B'); // down
+    await tick();
+    await tick();
+    expect(spies.onFocusChange).toHaveBeenLastCalledWith('feat');
+    expect(lastFrame()).toContain('focus:feat');
+
+    stdin.write('\x1B[A'); // up
+    await tick();
+    await tick();
+    expect(spies.onFocusChange).toHaveBeenLastCalledWith('main');
+    expect(lastFrame()).toContain('focus:main');
+  });
+
+  it('guards navigation when a modal is open', async () => {
+    const spies = makeSpies();
+    const { stdin, lastFrame } = render(<Harness spies={spies} isModalOpen />);
+    await tick();
+
+    stdin.write('\x1B[B');
+    await tick();
+
+    expect(spies.onFocusChange).not.toHaveBeenCalled();
+    expect(lastFrame()).toContain('focus:main');
+  });
+
+  it('toggles expansion and collapses with left arrow', async () => {
+    const spies = makeSpies();
+    const { stdin, lastFrame } = render(
+      <Harness spies={spies} initialExpanded={['main']} />
+    );
+    await tick();
+
+    stdin.write('\x1B[D'); // left arrow should collapse
+    await tick();
+    expect(spies.onToggleExpand).toHaveBeenCalledWith('main');
+    expect(lastFrame()).toContain('expanded:');
+
+    stdin.write(' ');
+    await tick();
+    expect(spies.onToggleExpand).toHaveBeenCalledWith('main');
+  });
+
+  it('fires action keys for copy, profile, and open editor', async () => {
+    const spies = makeSpies();
+    const { stdin } = render(<Harness spies={spies} />);
+    await tick();
+
+    stdin.write('c');
+    stdin.write('p');
+    stdin.write('\r');
+    await tick();
+
+    expect(spies.onCopyTree).toHaveBeenCalledWith('main');
+    expect(spies.onOpenProfileSelector).toHaveBeenCalledWith('main');
+    expect(spies.onOpenEditor).toHaveBeenCalledWith('main');
+  });
+
+  it('adjusts visible window when focus moves past viewport', async () => {
+    const spies = makeSpies();
+    const { stdin, lastFrame } = render(<Harness spies={spies} viewportSize={2} />);
+    await tick();
+
+    stdin.write('\x1B[B');
+    await tick();
+    stdin.write('\x1B[B'); // move to index 2
+    await tick();
+    await tick();
+    await tick();
+
+    expect(lastFrame()).toContain('focus:bug');
+    expect(lastFrame()).toContain('window:1-3');
+  });
+});


### PR DESCRIPTION
## Summary
- Add useDashboardNav hook to handle dashboard focus, expansion, and action keys with viewport tracking.
- Wire App to the dashboard nav hook, disable conflicting file-tree keyboard handlers, and window WorktreeOverview rendering.
- Add unit coverage for dashboard navigation behavior and viewport slicing.

## Testing
- npm test

Closes #148