### PR TITLE
feat: open worktrees from dashboard

### DIFF
--- a/src/components/WorktreeCard.tsx
+++ b/src/components/WorktreeCard.tsx
@@ -105,7 +105,7 @@ export const WorktreeCard: React.FC<WorktreeCardProps> = ({
             <Text color={palette.accent.primary}>[p]</Text> Profile{'  '}
             {showOpenEditorHint && (
               <>
-                <Text color={palette.accent.primary}>[Enter]</Text> VS Code
+                <Text color={palette.accent.primary}>[Enter]</Text> Editor
               </>
             )}
           </Text>


### PR DESCRIPTION
Closes #151

## Summary
- add openWorktreeInEditor for workspace/editor launches with shared spawn handling and default opener fallback
- wire dashboard Enter action to open the focused worktree and emit notifications; clarify footer hint
- extend opener tests to cover worktree paths and error handling

## Testing
- npm test