### PR TITLE
StatusBar Tuning for Dashboard Context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1087,6 +1087,9 @@ const AppContent: React.FC<AppProps> = ({ cwd, config: initialConfig, noWatch, n
         activeRootPath={activeRootPath}
         commandMode={commandMode}
         isIdle={isIdle}
+        worktreeChanges={worktreeChanges}
+        focusedWorktreeId={focusedWorktreeId}
+        worktrees={sortedWorktrees}
       />
       {isProfileSelectorOpen && (
         <Box

--- a/src/hooks/useDashboardNav.ts
+++ b/src/hooks/useDashboardNav.ts
@@ -180,15 +180,8 @@ export function useDashboardNav({
         return;
       }
 
-      if (key.home) {
-        focusExact(0);
-        return;
-      }
-
-      if (key.end) {
-        focusExact(worktrees.length - 1);
-        return;
-      }
+      // Note: Home/End keys are not exposed in Ink's Key type as of v6.5
+      // These would need to be detected via raw terminal input if needed
 
       handlePrimaryActions(input, key);
     },


### PR DESCRIPTION
## Summary
Updates StatusBar to display dashboard-relevant metrics when operating in worktree dashboard mode. The component now aggregates changed files across all worktrees and highlights the focused worktree's changes for better context awareness.

Closes #155

## Changes Made
- Add worktreeChanges, focusedWorktreeId, and worktrees props to StatusBar
- Calculate total changed files across all worktrees
- Display focused worktree changes separately
- Show focused worktree branch in AI status line
- Update CopyTree button to use focused worktree path
- Maintain backward compatibility when dashboard props not provided
- Fix TypeScript errors in useDashboardNav (remove unsupported Home/End keys)

## Implementation Notes

**Context & rationale**
- StatusBar now displays dashboard-relevant metrics when worktree context is available
- Aggregates changed files across all worktrees for comprehensive overview
- Shows focused worktree changes separately for context-aware detail
- AI status references focused worktree branch for better orientation
- CopyTree button defaults to focused worktree path in dashboard mode

**Implementation details**
- Added optional props to StatusBar: `worktreeChanges`, `focusedWorktreeId`, `worktrees`
- Total changed files calculated by aggregating all worktrees when dashboard context is available
- Focused changes extracted from focused worktree's change count
- AI status line shows focused worktree branch name when available
- CopyTree button and mouse click handler use focused worktree path in dashboard context
- Falls back to legacy behavior when dashboard props are not provided

## Breaking Changes & Migration Hints
- None - backward compatible with existing single-worktree usage
- No migration required - props are optional, falls back to existing behavior