### PR TITLE
feat(header): add dashboard-aware worktree statistics

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -246,6 +246,13 @@ const AppContent: React.FC<AppProps> = ({ cwd, config: initialConfig, noWatch, n
 
   const currentWorktree = worktreesWithStatus.find(wt => wt.id === activeWorktreeId) || null;
 
+  // Compute active worktree count (worktrees with changes)
+  const activeWorktreeCount = useMemo(() => {
+    return worktreesWithStatus.filter(wt =>
+      worktreeChanges.get(wt.id)?.changedFileCount ?? 0 > 0
+    ).length;
+  }, [worktreesWithStatus, worktreeChanges]);
+
   const activeWorktreeChanges = useMemo(
     () => (activeWorktreeId ? worktreeChanges.get(activeWorktreeId) : undefined),
     [activeWorktreeId, worktreeChanges]
@@ -1054,6 +1061,7 @@ const AppContent: React.FC<AppProps> = ({ cwd, config: initialConfig, noWatch, n
         filterQuery={filterQuery}
         currentWorktree={currentWorktree}
         worktreeCount={worktreesWithStatus.length}
+        activeWorktreeCount={activeWorktreeCount}
           onWorktreeClick={() => events.emit('ui:modal:open', { id: 'worktree' })}
           identity={projectIdentity}
           config={effectiveConfig}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,6 +13,7 @@ interface HeaderProps {
   filterQuery: string;
   currentWorktree?: Worktree | null;
   worktreeCount?: number;
+  activeWorktreeCount?: number;
   onWorktreeClick?: () => void;
   identity: ProjectIdentity;
   config: CanopyConfig;
@@ -29,6 +30,7 @@ export const Header: React.FC<HeaderProps> = ({
   filterQuery,
   currentWorktree,
   worktreeCount = 0,
+  activeWorktreeCount = 0,
   onWorktreeClick,
   identity,
   config,
@@ -74,6 +76,9 @@ export const Header: React.FC<HeaderProps> = ({
   // Show git-only mode button only when git is enabled
   const showGitOnlyButton = gitEnabled && onToggleGitOnlyMode !== undefined;
 
+  const worktreeLabel = `${worktreeCount} ${worktreeCount === 1 ? 'worktree' : 'worktrees'}`;
+  const activeLabel = `${activeWorktreeCount} active`;
+
   // Calculate mood-based gradient (or use project identity)
   const gradient = getHeaderGradient(
     gitStatus,
@@ -91,18 +96,22 @@ export const Header: React.FC<HeaderProps> = ({
       </Gradient>
 
       {showWorktreeIndicator && (
-        <>
+        <Box
+          flexDirection="row"
+          alignItems="center"
+          // @ts-ignore - Ink's Box does not include `onClick` in the current type definitions
+          onClick={onWorktreeClick}
+        >
           <Text dimColor> • </Text>
-          <Text dimColor>wt </Text>
           <Text
             color={isSwitching ? palette.alert.warning : palette.accent.primary}
             bold={onWorktreeClick !== undefined}
             underline={onWorktreeClick !== undefined}
           >
-            {isSwitching ? '⟳ ' : ''}[{truncatedBranchName}]
+            {isSwitching ? '⟳ ' : ''}{truncatedBranchName}
           </Text>
-          <Text dimColor> ({worktreeCount})</Text>
-        </>
+          <Text dimColor> ({worktreeLabel}, {activeLabel})</Text>
+        </Box>
       )}
 
       <Text dimColor> • </Text>

--- a/tests/components/Header.test.tsx
+++ b/tests/components/Header.test.tsx
@@ -58,6 +58,7 @@ describe('Header', () => {
           filterQuery=""
           currentWorktree={mockWorktree}
           worktreeCount={3}
+          activeWorktreeCount={1}
           identity={mockIdentity}
           config={DEFAULT_CONFIG}
         />
@@ -65,9 +66,8 @@ describe('Header', () => {
 
       const output = lastFrame();
       expect(output).toContain('Canopy');
-      expect(output).toContain('wt');
-      expect(output).toContain('[main]');
-      expect(output).toContain('(3)');
+      expect(output).toContain('main');
+      expect(output).toContain('(3 worktrees, 1 active)');
     });
 
     it('shows relative path when in worktree subdirectory', () => {
@@ -176,9 +176,8 @@ describe('Header', () => {
       );
 
       const output = lastFrame();
-      expect(output).toContain('wt');
-      expect(output).toContain('[main]');
-      expect(output).toContain('(2)');
+      expect(output).toContain('main');
+      expect(output).toContain('(2 worktrees, 0 active)');
       expect(output).toContain('[*]');
       expect(output).toContain('*.tsx');
     });
@@ -230,7 +229,7 @@ describe('Header', () => {
       );
 
       const output = lastFrame();
-      expect(output).toContain('(1)');
+      expect(output).toContain('(1 worktree');
     });
 
     it('handles multiple worktrees', () => {
@@ -247,7 +246,65 @@ describe('Header', () => {
       );
 
       const output = lastFrame();
-      expect(output).toContain('(5)');
+      expect(output).toContain('(5 worktrees');
+    });
+
+    it('shows active worktree count when provided', () => {
+      const { lastFrame } = renderWithTheme(
+        <Header
+          cwd="/Users/dev/project"
+          filterActive={false}
+          filterQuery=""
+          currentWorktree={mockWorktree}
+          worktreeCount={5}
+          activeWorktreeCount={2}
+          identity={mockIdentity}
+          config={DEFAULT_CONFIG}
+        />
+      );
+
+      const output = lastFrame();
+      expect(output).toContain('(5 worktrees, 2 active)');
+    });
+
+    it('shows zero active worktrees correctly', () => {
+      const { lastFrame } = renderWithTheme(
+        <Header
+          cwd="/Users/dev/project"
+          filterActive={false}
+          filterQuery=""
+          currentWorktree={mockWorktree}
+          worktreeCount={3}
+          activeWorktreeCount={0}
+          identity={mockIdentity}
+          config={DEFAULT_CONFIG}
+        />
+      );
+
+      const output = lastFrame();
+      expect(output).toContain('(3 worktrees, 0 active)');
+    });
+
+    it('renders badge without square brackets around branch name', () => {
+      const { lastFrame } = renderWithTheme(
+        <Header
+          cwd="/Users/dev/project"
+          filterActive={false}
+          filterQuery=""
+          currentWorktree={mockWorktree}
+          worktreeCount={3}
+          activeWorktreeCount={1}
+          identity={mockIdentity}
+          config={DEFAULT_CONFIG}
+        />
+      );
+
+      const output = lastFrame();
+      // Should have branch name without brackets
+      expect(output).toContain('main');
+      expect(output).not.toMatch(/\[main\]/);
+      // Should have the new format
+      expect(output).toContain('(3 worktrees, 1 active)');
     });
 
     it('handles detached HEAD state', () => {
@@ -272,7 +329,7 @@ describe('Header', () => {
       );
 
       const output = lastFrame();
-      expect(output).toContain('[detached]');
+      expect(output).toContain('detached');
     });
 
     it('handles feature branch with slashes', () => {
@@ -297,7 +354,7 @@ describe('Header', () => {
       );
 
       const output = lastFrame();
-      expect(output).toContain('[feature/auth]');
+      expect(output).toContain('feature/auth');
     });
 
     it('truncates very long branch names', () => {
@@ -323,7 +380,7 @@ describe('Header', () => {
 
       const output = lastFrame();
       // Should contain exact truncated string (19 chars + ellipsis = 20 total)
-      expect(output).toContain('[feature/this-is-a-v…]');
+      expect(output).toContain('feature/this-is-a-v…');
       // Full branch name should NOT be present
       expect(output).not.toContain('feature/this-is-a-very-long-branch-name-that-should-be-truncated');
     });
@@ -342,9 +399,8 @@ describe('Header', () => {
       );
 
       const output = lastFrame();
-      expect(output).toContain('wt');
-      expect(output).toContain('[main]');
-      expect(output).toContain('(0)');
+      expect(output).toContain('main');
+      expect(output).toContain('(0 worktrees, 0 active)');
     });
 
     it('does not show worktree indicator when currentWorktree is null', () => {
@@ -361,7 +417,7 @@ describe('Header', () => {
       );
 
       const output = lastFrame();
-      expect(output).not.toContain('wt');
+      expect(output).not.toContain('worktrees');
     });
 
     it('does not show worktree indicator when currentWorktree is undefined', () => {
@@ -378,7 +434,7 @@ describe('Header', () => {
       );
 
       const output = lastFrame();
-      expect(output).not.toContain('wt');
+      expect(output).not.toContain('worktrees');
     });
 
     it('uses worktree name as fallback when branch is undefined (detached HEAD)', () => {
@@ -403,8 +459,8 @@ describe('Header', () => {
       );
 
       const output = lastFrame();
-      expect(output).toContain('[canopy-issue-42]');
-      expect(output).not.toContain('[detached]');
+      expect(output).toContain('canopy-issue-42');
+      expect(output).not.toContain('detached');
     });
   });
 
@@ -502,9 +558,8 @@ describe('Header', () => {
 
       const output = lastFrame();
       expect(output).toContain('Canopy');
-      expect(output).not.toContain('wt');
-      expect(output).not.toContain('[main]');
-      expect(output).not.toContain('(3)');
+      expect(output).not.toContain('main');
+      expect(output).not.toContain('worktrees');
     });
 
     it('shows worktree indicator when showInHeader is true (default)', () => {
@@ -521,9 +576,8 @@ describe('Header', () => {
       );
 
       const output = lastFrame();
-      expect(output).toContain('wt');
-      expect(output).toContain('[main]');
-      expect(output).toContain('(3)');
+      expect(output).toContain('main');
+      expect(output).toContain('(3 worktrees');
     });
 
     it('defaults to showing worktree indicator when config.worktrees is undefined', () => {
@@ -545,8 +599,8 @@ describe('Header', () => {
       );
 
       const output = lastFrame();
-      expect(output).toContain('wt');
-      expect(output).toContain('[main]');
+      expect(output).toContain('main');
+      expect(output).toContain('worktrees');
     });
   });
 });


### PR DESCRIPTION
## Summary
Update Header component to display aggregate worktree statistics for the dashboard view, showing total worktrees and active worktrees (those with changes).

Closes #154

## Changes Made
- Add activeWorktreeCount prop to Header component
- Compute active count as worktrees with changes in App.tsx
- Update badge format to "branch (X worktrees, Y active)"
- Add singular/plural handling for worktree labels
- Wrap badge in clickable Box for WorktreePanel navigation
- Update all existing tests and add 3 new test cases

## Implementation Notes

### Context & rationale
* Header was file-browser focused, needed dashboard-aware metrics
* Shows total worktrees and active (with changes) count
* Badge remains clickable to open WorktreePanel modal
* Mood gradient preserved from #105

### Implementation details
* Added `activeWorktreeCount` prop to HeaderProps
* Computed active count in App.tsx as `worktrees.filter(wt => worktreeChanges.get(wt.id)?.changedFileCount > 0).length`
* Updated badge rendering to show "branch (X worktrees, Y active)" format
* Added proper singular/plural handling: "1 worktree" vs "2 worktrees"
* Wrapped badge in clickable Box component with `onClick={onWorktreeClick}` for better UX
* Kept gradient, bold/underline styling, and switching indicator unchanged
* Updated all 25 existing tests and added 3 new test cases for active count scenarios

## Breaking Changes & Migration Hints

### Breaking changes
* Badge text format changed from "[branch] (count)" to "branch (X worktrees, Y active)"
* Removed "wt" prefix and square brackets around branch name for cleaner look

### Migration hints
* N/A - UI change only, no API or config changes

## Follow-up Tasks
* Pre-existing build error in `useDashboardNav.ts` (not related to this change)