### PR TITLE
Documentation Rewrite for Worktree Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,87 +1,109 @@
 # Canopy
 
-> Rise above the forest floor. Watch your AI agents work from the canopy.
+> Your AI Agent Dashboard. Watch your AI agents work from the canopy—the highest vantage point in the forest.
 
-A terminal-based file browser built with Ink (React for CLIs) that transforms your terminal into a lightweight IDE. The canopy is where you get perspective—the highest vantage point in the forest, where you can see everything below.
+**Canopy is a Worktree Context Dashboard for AI-driven development.** Monitor multiple AI agents working across git worktrees simultaneously, with one-keystroke context extraction and always-visible activity summaries.
 
-## The Philosophy
+## The Problem: Agent Blindness
 
-### The Problem: Lost Visual Context
+When working with CLI-based AI coding agents (Claude Code, Gemini CLI, Codex, etc.), you face critical visibility gaps:
 
-When working with CLI-based AI coding agents (Claude Code, Gemini CLI, Codex, etc.), you lose the visual context that traditional IDEs provide. You can't easily see:
-- What files the AI just created
-- Which files are being modified in real-time
-- What's been deleted or moved
-- The overall structure of your project as it evolves
+- **Which worktree is the agent touching?** When running multiple feature branches, you can't tell where changes are happening
+- **What files are being modified?** Real-time file changes happen invisibly in background worktrees
+- **What's the current state?** No way to glance and see all active development contexts at once
+- **How do I give the agent context?** Manually building file lists or running `copytree` commands breaks flow
 
-Running `ls -R` or `git status` constantly breaks your flow and pulls focus from the agent's work.
+Running `git status` across multiple worktrees or constantly checking different directories pulls you out of the agent conversation.
 
-### The Solution: The Ghostty Stack
+## The Solution: Worktree Context Dashboard
 
-**Canopy sits in a narrow, balanced split in your terminal multiplexer** (Ghostty, tmux, or any terminal with split support). Think of it as the missing file tree sidebar for your terminal-based workflow:
+**Canopy is your always-on context dashboard.** It sits in a narrow terminal split showing you a real-time view of all your git worktrees, their changes, and their activity state—with AI-powered summaries of what's happening in each one.
 
 ```
-┌─────────────────┐  ┌──────────────────────────────────────┐
-│ Canopy          │  │ AI Agent (Claude Code)               │
-│ (passive view)  │  │ (active work)                        │
-├─────────────────┤  ├──────────────────────────────────────┤
-│                 │  │                                      │
-│ src/            │  │ > Implementing authentication...     │
-│   App.ts        │  │                                      │
-│ M auth.ts       │  │ Progress: [===========   ] 60%       │
-│ A login.ts      │  │                                      │
-│ tests/          │  │ $ npm test                           │
-│ M auth.test.ts  │  │ ✓ All tests passing                  │
-│                 │  │                                      │
-└─────────────────┘  └──────────────────────────────────────┘
-  60-70 cols           Remaining terminal width
+┌──────────────────────────────────────────────────────┐
+│ Canopy • 3 worktrees                                 │
+├──────────────────────────────────────────────────────┤
+│ ╔══════════════════════════════════════════════════╗ │
+│ ║ main • ~/canopy                         [ACTIVE] ║ │
+│ ╠══════════════════════════════════════════════════╣ │
+│ ║ Summary: Implementing new dashboard UI           ║ │
+│ ║ 12 files • 5 modified, 3 added, 1 deleted        ║ │
+│ ║                                                   ║ │
+│ ║ M src/App.tsx                                    ║ │
+│ ║ M src/components/WorktreeCard.tsx                ║ │
+│ ║ A src/hooks/useDashboardNav.ts                   ║ │
+│ ║ ... and 9 more                                   ║ │
+│ ║                                                   ║ │
+│ ║ [space] toggle • [c] copy • [p] profile • [↵] open │
+│ ╚══════════════════════════════════════════════════╝ │
+│                                                      │
+│ ┌────────────────────────────────────────────────┐   │
+│ │ feature/auth • ~/canopy-auth          [STABLE] │   │
+│ ├────────────────────────────────────────────────┤   │
+│ │ Summary: Authentication system implementation  │   │
+│ │ 3 files • 2 modified, 1 added                  │   │
+│ └────────────────────────────────────────────────┘   │
+│                                                      │
+│ ┌────────────────────────────────────────────────┐   │
+│ │ bugfix/leak • ~/canopy-bugfix           [STALE] │   │
+│ ├────────────────────────────────────────────────┤   │
+│ │ Summary: Memory leak investigation             │   │
+│ │ No changes (last activity: 3 days ago)         │   │
+│ └────────────────────────────────────────────────┘   │
+├──────────────────────────────────────────────────────┤
+│ Press ? for help • / for search                      │
+└──────────────────────────────────────────────────────┘
 ```
 
-**Left pane:** Canopy provides passive observability—a real-time view of your file system
-**Right pane(s):** Your AI agent does the active work
+### Worktree-First Philosophy
 
-You simply **glance left** to see what's happening. No commands needed.
+**Changed Files, Not File Systems.** Canopy doesn't show you a deep file tree—it shows you what's changing across all your worktrees. Each card displays:
 
-### Why This Matters
+- **Worktree name and branch** with activity mood indicator
+- **AI-generated summary** of what's happening (e.g., "Implementing authentication")
+- **Changed files only** with git status markers (M/A/D)
+- **One-keystroke actions**: CopyTree context, profile selector, editor launch
 
-- **Instant Awareness:** See modifications (`M`), additions (`A`), deletions (`D`) as they happen
-- **Context Preservation:** Keep your mental model of the project structure intact
-- **Workflow Integration:** Works seamlessly with git worktrees for multi-task AI workflows
-- **Zero Friction:** No switching between windows, tabs, or running status commands
+**Traditional file browsing available when needed via fuzzy search** (press `/` to search for any file across all worktrees).
 
-## Features
+## Key Features
 
-### Real-time Agent Monitoring
-Git status markers show exactly what your AI agent is touching. Modified files appear with `M`, new files with `A`, deleted with `D`. No manual `git status` needed—just look left.
+### Multi-Worktree Awareness
+See all your git worktrees at once, sorted by activity. Active worktrees appear first, followed by stable ones, then stale. Each card shows the branch, path, and current state.
 
-### Instant Updates
-Live file watching means the tree updates immediately as the AI writes to disk. See new test files appear, watch refactors move code, observe deletions—all in real-time without manual refresh.
+### AI-Powered Summaries
+Each worktree card displays an AI-generated summary of what's happening based on file changes and commit messages. Powered by GPT-5 Nano for fast, context-aware descriptions.
 
-### Split-Pane Optimized UI
-Designed specifically for narrow widths (60-70 columns). Compact mode hides unnecessary metadata, maximizing screen real estate for your code panes while still providing complete context.
+### Mood Indicators
+Worktrees are automatically categorized by activity level:
+- **ACTIVE** (orange border): Recent changes (< 1 hour ago)
+- **STABLE** (blue border): Some changes but not recent
+- **STALE** (gray border): No recent activity (> 24 hours)
+- **ERROR** (red border): Git status fetch failed
 
-### Intelligent Context Switching
-Full git worktree support detects and switches between branches instantly. Jump between different agent tasks or experiments without losing your place. Each worktree remembers its own expanded folders and selected files.
+### One-Keystroke Context Extraction
+Press `c` on any worktree to copy its changed files to your clipboard via CopyTree integration. Press `p` to open the profile selector and choose from configured CopyTree profiles for different AI context formats.
 
-### Mouse & Keyboard Navigation
-Click to select files and expand folders, or use keyboard shortcuts. Built for efficiency whether you're mouse-first or keyboard-driven.
+**CopyTree profiles** let you define preset CLI argument combinations in `.canopy.json`:
 
-### Smart Filtering
-Quickly filter the tree by name or git status (`/filter modified` shows only changed files). Perfect for focusing on what the AI just touched.
+```json
+{
+  "copytreeProfiles": {
+    "default": { "args": ["-r"], "description": "Standard recursive scan" },
+    "tests": { "args": ["--filter", "tests/**", "-r"], "description": "Tests only" },
+    "minimal": { "args": ["--tree-only"], "description": "Structure only" }
+  }
+}
+```
 
-### Hierarchical Tree View
-Collapsible folders with infinite depth. Respects `.gitignore` by default, with options to show hidden files or apply custom ignore patterns.
+### VS Code Integration
+Press `Enter` on any worktree card to open it in VS Code (or your configured editor). The editor opens in the worktree's root directory, preserving your context.
 
-## CopyTree Integration
+### Fuzzy Search
+Press `/` to open fuzzy search and find any file across all worktrees. Search replaces the traditional file browser—use it when you need to dive deep into specific files.
 
-Canopy isn't just for observing—it's for **giving context** to your AI.
-
-Press `c` on any file to copy its path to your clipboard. Use it to:
-- Quickly reference files in your next prompt to the AI
-- Share context between different AI sessions
-- Build up file lists for batch operations
-
-Integration with [CopyTree](https://github.com/gregpriday/copytree) allows one-keystroke context extraction directly into your LLM prompts.
+### Live Updates
+File watching keeps the dashboard current. As AI agents modify files, you see changes appear in real-time on the relevant worktree card—no manual refresh needed.
 
 ## Installation
 
@@ -95,7 +117,7 @@ npm install -g @gpriday/canopy
 1. Launch Ghostty
 2. Split vertically (Cmd+D or Ctrl+Shift+\)
 3. In the left pane: `canopy`
-4. Resize to ~60-70 columns wide
+4. Resize to ~60-80 columns wide
 5. Save the layout for future sessions
 
 **tmux Users:** Add to your `.tmux.conf`:
@@ -114,43 +136,42 @@ canopy
 # Run in specific directory
 canopy /path/to/project
 
-# Start with a filter applied
-canopy --filter "*.ts"
-
 # Disable file watching (for very large projects)
 canopy --no-watch
 
-# Show hidden files
-canopy --hidden
+# Disable git integration
+canopy --no-git
 ```
 
 ### Keyboard Shortcuts
 
-**Navigation:**
-- `↑/↓` - Navigate tree
-- `←/→` - Collapse folder / expand folder or open file
+**Dashboard Navigation:**
+- `↑/↓` - Navigate worktree cards
+- `Space` - Expand/collapse card to see changed files
 - `PageUp/PageDown` - Page navigation
-- `Space` - Toggle folder expansion
-- `Enter` - Open file or toggle folder
+- `Home/End` - Jump to first/last worktree
 
-**File Actions:**
-- `c` - Copy file path to clipboard
-- `m` - Open context menu
+**Worktree Actions:**
+- `c` - Copy changed files via CopyTree (default profile)
+- `p` - Open CopyTree profile selector
+- `Enter` - Open worktree in VS Code/editor
+- `w` - Cycle to next worktree
+- `W` - Open worktree panel (full list)
 
-**Commands & UI:**
-- `/` - Open command bar
+**Search & Commands:**
+- `/` - Fuzzy search across all worktrees
 - `Ctrl+F` - Quick filter
-- `Esc` - Close modals/filter
+- `Esc` - Close modals/search
 - `?` - Toggle help
 
-**Git & Worktrees:**
-- `g` - Toggle git status visibility
-- `w` - Cycle to next worktree
-- `W` - Open worktree panel
-
 **Other:**
+- `g` - Toggle git status visibility
 - `r` - Manual refresh
 - `q` - Quit
+
+### Traditional File Tree Mode
+
+Need to browse the full file hierarchy? The original tree view is available via the `/tree` command. This provides the traditional collapsible folder view when you need deep file exploration.
 
 ## Configuration
 
@@ -161,14 +182,24 @@ Create a `.canopy.json` file in your project root or `~/.config/canopy/config.js
   "editor": "code",
   "editorArgs": ["-r"],
   "showGitStatus": true,
-  "showHidden": false,
-  "respectGitignore": true,
+  "copytreeProfiles": {
+    "default": {
+      "args": ["-r"],
+      "description": "Standard recursive scan"
+    },
+    "tests": {
+      "args": ["--filter", "tests/**/*.ts", "-r"],
+      "description": "Tests only"
+    },
+    "minimal": {
+      "args": ["--tree-only"],
+      "description": "Structure only"
+    }
+  },
   "ui": {
     "compactMode": true,
-    "leftClickAction": "select"
+    "moodGradients": true
   },
-  "sortBy": "name",
-  "sortDirection": "asc",
   "refreshDebounce": 100
 }
 ```
@@ -177,31 +208,27 @@ Create a `.canopy.json` file in your project root or `~/.config/canopy/config.js
 
 - **`editor`** - Command to open files (default: `code`)
 - **`editorArgs`** - Arguments for the editor (default: `["-r"]`)
-- **`openers`** - Custom openers by file extension/glob pattern
+- **`copytreeProfiles`** - CopyTree profile presets (each profile has `args` array and optional `description`)
 - **`showGitStatus`** - Display git status indicators (default: `true`)
-- **`showHidden`** - Show hidden files (default: `false`)
-- **`respectGitignore`** - Respect .gitignore patterns (default: `true`)
-- **`customIgnores`** - Additional glob patterns to ignore
-- **`sortBy`** - Sort files by: `name`, `size`, `modified`, `type` (default: `name`)
-- **`sortDirection`** - Sort direction: `asc` or `desc` (default: `asc`)
-- **`maxDepth`** - Maximum tree depth (default: unlimited)
 - **`refreshDebounce`** - File watcher debounce in ms (default: `100`)
 - **`ui.compactMode`** - Compact display mode (default: `true`)
-- **`ui.leftClickAction`** - Mouse left click behavior: `open` or `select` (default: `select`)
+- **`ui.moodGradients`** - Show mood-based header gradients (default: `true`)
 
-## The Future: Autonomous Observer
+See [docs/COPYTREE_INTEGRATION.md](docs/COPYTREE_INTEGRATION.md) for detailed CopyTree profile documentation.
 
-Canopy is evolving from a passive viewer to an active participant in AI-driven development:
+## Why This Matters
 
-### Planned Features
+### Solves Agent Blindness
+No more wondering "what's the agent doing?" Just glance left and see exactly which worktree is active and what files are changing.
 
-- **AI-Driven Insights:** "What happened while I was gone?" summaries powered by worktree analysis
-- **Intelligent Change Detection:** Automatic categorization of changes (refactoring, new features, bug fixes)
-- **Multi-Agent Coordination:** Visual indicators for which agent touched which files in collaborative sessions
-- **Context Recommendations:** Smart suggestions for what files to include in your next AI prompt
-- **Session Replay:** Visual timeline of how your project evolved during an AI session
+### Context Switching Made Effortless
+Jump between agent tasks instantly. See all your feature branches, experiments, and bug fixes in one view with their current activity state.
 
-The goal: Transform Canopy from an observation tool into an intelligent partner that helps you understand and guide your AI agents.
+### One-Keystroke AI Context
+Stop manually building file lists for your AI prompts. Press `c` to copy a pre-configured context packet with exactly the files you need.
+
+### Multi-Agent Coordination
+When multiple AI agents work across different worktrees, Canopy shows you the full picture—who's touching what, where changes are happening, and what's the current state.
 
 ## Development
 
@@ -226,6 +253,13 @@ npm run typecheck
 ```
 
 **Important:** You must run `npm run build` after making code changes to verify them with `npm start` or `canopy`.
+
+## Documentation
+
+- **[SPEC.md](SPEC.md)** - Complete technical specification and architecture
+- **[CLAUDE.md](CLAUDE.md)** - AI agent development instructions
+- **[docs/KEYBOARD_SHORTCUTS.md](docs/KEYBOARD_SHORTCUTS.md)** - Full keyboard reference
+- **[docs/COPYTREE_INTEGRATION.md](docs/COPYTREE_INTEGRATION.md)** - CopyTree profiles and context extraction
 
 ## License
 

--- a/docs/COPYTREE_INTEGRATION.md
+++ b/docs/COPYTREE_INTEGRATION.md
@@ -1,0 +1,441 @@
+# CopyTree Integration
+
+Complete guide to using CopyTree profiles with Canopy for one-keystroke AI context extraction.
+
+## Overview
+
+Canopy integrates deeply with [CopyTree](https://github.com/gregpriday/copytree) to provide instant context packet generation for AI prompts. Instead of manually running `copytree` commands, you can:
+
+1. **Press `c`** on any worktree card → copies changed files with default profile
+2. **Press `p`** → selects a profile → **then press `c`** → copies with selected profile
+3. **Paste into your AI prompt** → LLM receives perfectly formatted context
+
+## Quick Start
+
+### Default Behavior
+
+Without any configuration, pressing `c` on a worktree card copies the changed files to your clipboard using CopyTree's default settings (`-r` flag for recursive).
+
+### Example Output
+
+```xml
+<file_tree>
+  <file path="src/App.tsx" />
+  <file path="src/components/WorktreeCard.tsx" />
+  <file path="src/hooks/useDashboardNav.ts" />
+</file_tree>
+```
+
+You can paste this directly into your AI conversation—the AI reads the referenced files automatically.
+
+## Configuring Profiles
+
+Create custom profiles in `.canopy.json` (project-level) or `~/.config/canopy/config.json` (global):
+
+```json
+{
+  "copytreeProfiles": {
+    "default": {
+      "args": ["-r"],
+      "description": "Standard recursive scan (uses .copytree.yml if present)"
+    },
+    "minimal": {
+      "args": ["--tree-only"],
+      "description": "Structure only, no file contents"
+    },
+    "tests": {
+      "args": ["--filter", "tests/**/*.ts", "-r"],
+      "description": "Tests only"
+    },
+    "debug": {
+      "args": ["-r", "--verbose"],
+      "description": "Recursive with debug output"
+    }
+  }
+}
+```
+
+### Profile Structure
+
+Each profile is an object with:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `args` | `string[]` | Yes | Array of CLI arguments to pass to `copytree` command |
+| `description` | `string` | No | Human-readable description shown in profile selector |
+
+**Example:**
+```json
+{
+  "args": ["--filter", "src/**/*.ts", "-r"],
+  "description": "Source TypeScript files only"
+}
+```
+
+## How Profiles Work
+
+### The Two-Step Process
+
+1. **Select profile** (optional): Press `p` → choose a profile → modal closes
+2. **Execute CopyTree**: Press `c` → runs CopyTree with the selected profile (or default if none selected)
+
+**Important:** The profile selector (`p` key) only **sets** the active profile—it doesn't execute CopyTree. You must press `c` after selecting a profile to actually copy files.
+
+### What Happens When You Press `c`
+
+When you press `c` on a worktree card, Canopy:
+
+1. Gets the changed files for the focused worktree (via git status)
+2. Resolves the profile arguments from config (using the last selected profile, or "default")
+3. Builds a CopyTree command: `copytree <args> <changed-file-paths>`
+4. Executes it and copies the output to your clipboard
+5. Shows a success notification: `✓ CopyTree completed`
+
+## Profile Examples
+
+### 1. Default (Standard Recursive)
+
+**Use case:** Quick context sharing with AI—uses CopyTree's default behavior.
+
+```json
+{
+  "default": {
+    "args": ["-r"],
+    "description": "Standard recursive scan"
+  }
+}
+```
+
+**Command executed:**
+```bash
+copytree -r src/App.tsx src/hooks/useDashboardNav.ts
+```
+
+### 2. Tree Only (No Contents)
+
+**Use case:** Share file structure without file contents.
+
+```json
+{
+  "minimal": {
+    "args": ["--tree-only"],
+    "description": "Structure only"
+  }
+}
+```
+
+**Command executed:**
+```bash
+copytree --tree-only src/App.tsx src/hooks/useDashboardNav.ts
+```
+
+### 3. Filtered (Tests Only)
+
+**Use case:** Share only test files with AI for debugging.
+
+```json
+{
+  "tests": {
+    "args": ["--filter", "tests/**/*.ts", "-r"],
+    "description": "Tests only"
+  }
+}
+```
+
+**Note:** The `--filter` flag is applied by CopyTree itself, and it further filters the already-filtered list of changed files from git status.
+
+### 4. Verbose/Debug
+
+**Use case:** Troubleshooting CopyTree execution.
+
+```json
+{
+  "debug": {
+    "args": ["-r", "--verbose"],
+    "description": "Recursive with debug output"
+  }
+}
+```
+
+## Using Profiles
+
+### Workflow
+
+1. **Focus a worktree card** with keyboard navigation (`↑`/`↓`)
+2. **(Optional) Select a profile:** Press `p` → choose from list → press `Enter`
+3. **Copy files:** Press `c`
+4. **Paste into AI prompt**
+
+### Profile Selector Modal
+
+When you press `p`:
+
+```
+┌────────────────────────────────────┐
+│ CopyTree Profile Selector          │
+├────────────────────────────────────┤
+│ > default (Standard recursive)     │
+│   minimal (Structure only)         │
+│   tests (Tests only)               │
+│   debug (Recursive with debug)     │
+└────────────────────────────────────┘
+```
+
+Use `↑`/`↓` to select, `Enter` to confirm, `Esc` to cancel.
+
+**After selecting:** The modal closes. The selected profile is now "active" for the next `c` press.
+
+### Success Notification
+
+After pressing `c`:
+
+```
+✓ CopyTree completed
+```
+
+The changed files are now on your clipboard, formatted according to the profile's arguments.
+
+## Advanced Usage
+
+### Custom CopyTree Arguments
+
+The `args` array accepts any valid CopyTree CLI arguments. Refer to `copytree --help` for the full list.
+
+**Common flags:**
+- `-r` - Recursive (include file contents)
+- `--tree-only` - Structure only (no contents)
+- `--filter <pattern>` - Filter files by glob pattern
+- `--format <format>` - Output format (xml, markdown, json)
+- `--verbose` - Show debug output
+
+### Example: Markdown with Filter
+
+```json
+{
+  "docs": {
+    "args": ["--format", "markdown", "--filter", "**/*.md", "-r"],
+    "description": "Documentation files in markdown format"
+  }
+}
+```
+
+### Example: JSON Output
+
+```json
+{
+  "json": {
+    "args": ["--format", "json", "-r"],
+    "description": "JSON format for programmatic use"
+  }
+}
+```
+
+## Implementation Details
+
+### Event System
+
+Internally, Canopy uses an event bus for CopyTree actions:
+
+```typescript
+import { events } from './services/events';
+
+// Event payload
+interface CopyTreePayload {
+  rootPath: string;
+  profile: string;
+  extraArgs: string[];
+  files: string[];  // Changed files from git status
+}
+
+// Emit event
+events.emit('file:copy-tree', {
+  rootPath: '/Users/name/canopy-issue-156',
+  profile: 'tests',
+  extraArgs: [],
+  files: ['src/App.tsx', 'tests/App.test.tsx']
+});
+```
+
+**Note:** The event uses `rootPath` (not `worktreeId`). Canopy converts the worktree ID to a root path before emitting.
+
+### Profile Resolution
+
+When you press `c`, Canopy:
+
+1. Looks up the profile name (from last `p` selection, or "default")
+2. Finds `config.copytreeProfiles[profileName]`
+3. Extracts `profile.args` array
+4. Executes: `copytree <args> <changed-files>`
+
+If the profile doesn't exist:
+- Falls back to `config.copytreeProfiles.default`
+- If default doesn't exist, uses built-in fallback: `["-r"]`
+- Logs a warning (not shown to user)
+
+### Fallback Behavior
+
+**Profile not found:**
+```typescript
+// Code logs warning, uses default profile
+// User sees: "✓ CopyTree completed" (no error shown)
+```
+
+**No changed files:**
+```typescript
+// CopyTree still executes but with empty file list
+// User sees: "✓ CopyTree completed"
+```
+
+**CopyTree command fails:**
+```typescript
+// Error is logged to console
+// User sees: "✗ CopyTree failed: <error message>"
+```
+
+## Best Practices
+
+### 1. Keep Profiles Simple
+
+CopyTree profiles are just CLI argument lists. Don't overcomplicate them:
+
+```json
+{
+  "good": {
+    "args": ["-r"],
+    "description": "Simple and clear"
+  },
+  "too-complex": {
+    "args": ["--filter", "**/*.{ts,tsx,js,jsx}", "--exclude", "node_modules", "--format", "markdown", "--tree-depth", "3", "-r"],
+    "description": "Hard to understand and maintain"
+  }
+}
+```
+
+### 2. Name Profiles Descriptively
+
+Use clear names that indicate purpose:
+- ✅ `tests`, `docs`, `source`, `minimal`
+- ❌ `p1`, `custom`, `thing`
+
+### 3. Use Descriptions
+
+The `description` field appears in the profile selector—make it helpful:
+
+```json
+{
+  "tests": {
+    "args": ["--filter", "tests/**", "-r"],
+    "description": "Tests only"  // Shows in selector
+  }
+}
+```
+
+### 4. Test Your Profiles
+
+After creating a profile, test it:
+1. Focus a worktree with changes
+2. Press `p`, select your profile, press `Enter`
+3. Press `c` to execute
+4. Paste the clipboard contents to verify output
+
+### 5. Check CopyTree Documentation
+
+Profile arguments are passed directly to CopyTree CLI. Consult `copytree --help` or [CopyTree docs](https://github.com/gregpriday/copytree) for available flags.
+
+## Troubleshooting
+
+### "CopyTree command not found"
+
+**Problem:** CopyTree CLI is not installed or not in PATH.
+
+**Solution:**
+```bash
+npm install -g copytree
+# or
+brew install copytree
+```
+
+### Profile Not Appearing in Selector
+
+**Problem:** Profile defined in config but not showing.
+
+**Solution:**
+- Verify JSON syntax in `.canopy.json`
+- Restart Canopy to reload config
+- Check config location: project `.canopy.json` or global `~/.config/canopy/config.json`
+
+### "Invalid profile args" Error on Startup
+
+**Problem:** Profile `args` field is not an array.
+
+**Solution:**
+```json
+{
+  "bad": {
+    "args": "-r"  // ❌ String, not array
+  },
+  "good": {
+    "args": ["-r"]  // ✅ Array of strings
+  }
+}
+```
+
+### Nothing Happens When Pressing `c`
+
+**Problem:** CopyTree executes but clipboard is empty.
+
+**Solution:**
+- Check if worktree has changed files (git status)
+- Verify CopyTree is installed: `which copytree`
+- Check terminal output for error messages
+- Try the `debug` profile with `--verbose` to see CopyTree output
+
+### Wrong Files Copied
+
+**Problem:** CopyTree copies unexpected files.
+
+**Solution:**
+- Remember: Canopy only passes **changed files** to CopyTree (from git status)
+- If you want all files, use the `/copytree` command directly (not implemented yet)
+- Check your `--filter` pattern if using one
+
+## Integration with AI Workflows
+
+### Claude Code Example
+
+```bash
+# In your Claude Code conversation:
+> I need help with the authentication worktree
+
+[Navigate to auth worktree in Canopy, press `c`]
+[Paste clipboard]
+
+> These are the changed files. Can you review for security issues?
+```
+
+### Profile for Different AI Tasks
+
+```json
+{
+  "copytreeProfiles": {
+    "review": {
+      "args": ["-r"],
+      "description": "Full context for code review"
+    },
+    "debug": {
+      "args": ["-r", "--verbose"],
+      "description": "Debug output included"
+    },
+    "minimal": {
+      "args": ["--tree-only"],
+      "description": "Structure only for architecture discussion"
+    }
+  }
+}
+```
+
+## See Also
+
+- [CopyTree Documentation](https://github.com/gregpriday/copytree)
+- [Keyboard Shortcuts](KEYBOARD_SHORTCUTS.md)
+- [Configuration Guide](../README.md#configuration)

--- a/docs/KEYBOARD_SHORTCUTS.md
+++ b/docs/KEYBOARD_SHORTCUTS.md
@@ -1,0 +1,171 @@
+# Keyboard Shortcuts Reference
+
+Complete keyboard shortcut reference for Canopy's Worktree Dashboard.
+
+## Dashboard Mode (Default)
+
+Canopy launches in Dashboard mode by default, displaying a vertical stack of worktree cards.
+
+### Navigation
+
+| Key | Action |
+|-----|--------|
+| `↑` | Move focus to previous worktree card |
+| `↓` | Move focus to next worktree card |
+| `Home` | Jump to first worktree |
+| `End` | Jump to last worktree |
+| `PageUp` | Scroll up one page |
+| `PageDown` | Scroll down one page |
+| `Space` | Toggle expansion of focused worktree card (show/hide changed files) |
+
+### Worktree Actions
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Open focused worktree in VS Code/configured editor |
+| `c` | Copy changed files to clipboard via CopyTree (default profile) |
+| `p` | Open CopyTree profile selector modal |
+| `w` | Cycle to next worktree (switches active worktree) |
+| `W` (Shift+w) | Open worktree panel (shows full list with selection) |
+
+### Search & Commands
+
+| Key | Action |
+|-----|--------|
+| `/` | Open fuzzy search modal (search files across all worktrees) |
+| `Ctrl+F` | Open filter command (pre-fills `/filter` in command bar) |
+| `Esc` | Close modals and overlays (see priority below) |
+| `?` | Toggle help modal (keyboard shortcuts reference) |
+
+**Esc Key Priority:**
+1. Help modal → closes if open
+2. Context menu → closes if open
+3. Worktree panel → closes if open
+4. Command bar → closes if open
+5. Profile selector modal → closes if open
+6. Recent activity modal → closes if open
+
+### Display & Settings
+
+| Key | Action |
+|-----|--------|
+| `g` | Toggle git status visibility (show/hide M/A/D markers) |
+| `r` | Manual refresh (force reload worktree status and summaries) |
+
+### App Control
+
+| Key | Action |
+|-----|--------|
+| `q` | Quit Canopy |
+| `Ctrl+C` | Force quit (emergency exit) |
+
+## Legacy Tree Mode
+
+Available via `/tree` command. Displays traditional hierarchical file browser.
+
+### Navigation
+
+| Key | Action |
+|-----|--------|
+| `↑` | Move selection up |
+| `↓` | Move selection down |
+| `←` | Collapse focused folder (or move to parent) |
+| `→` | Expand focused folder (or open file) |
+| `Home` | Jump to first item |
+| `End` | Jump to last item |
+| `PageUp` | Scroll up one page |
+| `PageDown` | Scroll down one page |
+| `Space` | Toggle folder expansion (without opening) |
+| `Enter` | Open file or toggle folder |
+
+### File Actions
+
+| Key | Action |
+|-----|--------|
+| `c` | Copy file path to clipboard (absolute or relative based on config) |
+| `m` | Open context menu for focused file/folder |
+
+### Search & Commands
+
+Same as Dashboard mode.
+
+## Modal-Specific Shortcuts
+
+### Fuzzy Search Modal
+
+| Key | Action |
+|-----|--------|
+| Type text | Filter files by name |
+| `↑` / `↓` | Navigate search results |
+| `Enter` | Open selected file |
+| `Esc` | Close fuzzy search |
+
+### Profile Selector Modal
+
+| Key | Action |
+|-----|--------|
+| `↑` / `↓` | Navigate profile list |
+| `Enter` | Execute CopyTree with selected profile |
+| `Esc` | Cancel and close modal |
+
+### Worktree Panel
+
+| Key | Action |
+|-----|--------|
+| `↑` / `↓` | Navigate worktree list |
+| `Enter` | Switch to selected worktree |
+| `Esc` | Close panel without switching |
+
+### Help Modal
+
+| Key | Action |
+|-----|--------|
+| `?` | Toggle help on/off |
+| `Esc` | Close help |
+| `q` | Close help |
+
+### Command Bar
+
+| Key | Action |
+|-----|--------|
+| Type text | Enter command or filter text |
+| `↑` / `↓` | Navigate command history |
+| `Enter` | Execute command |
+| `Esc` | Close command bar |
+| `Tab` | Autocomplete (if available) |
+
+## Global Keys
+
+These keys work regardless of mode or modal state:
+
+| Key | Action |
+|-----|--------|
+| `?` | Toggle help modal |
+| `Ctrl+C` | Force quit |
+
+## Tips
+
+### Efficient Workflow
+
+1. **Dashboard Navigation:** Use `j`/`k` or arrow keys to move between worktrees
+2. **Quick Context:** Press `c` to copy changed files for the focused worktree
+3. **Custom Profiles:** Press `p` to choose specialized CopyTree profiles (tests only, docs, etc.)
+4. **Deep Dive:** Press `/` to fuzzy search when you need to find a specific file
+5. **Editor Integration:** Press `Enter` to jump into VS Code at the worktree root
+
+### Keyboard-First vs Mouse
+
+All actions are keyboard-accessible, but mouse support is available:
+- Click worktree card header to expand/collapse
+- Click file names to open in editor
+- Right-click for context menus (where supported by terminal)
+
+### Modal Discipline
+
+When multiple modals are open, `Esc` closes them in priority order. Press `Esc` repeatedly to dismiss all overlays and return to the dashboard.
+
+## Customization
+
+Future versions will support custom keybindings via `.canopy.json`. For now, shortcuts are fixed but optimized for common workflows.
+
+See [Configuration](../README.md#configuration) for other customization options.


### PR DESCRIPTION
## Summary

Complete documentation rewrite to reflect Canopy's Worktree Dashboard architecture. All documentation now consistently describes Canopy as a "Worktree Context Dashboard for AI-driven development" rather than a file browser.

Closes #156

## Changes Made

- Rewrite README.md to position Canopy as Worktree Context Dashboard
- Update SPEC.md with WorktreeOverview/WorktreeCard component hierarchy
- Update CLAUDE.md with dashboard-specific hooks and navigation
- Add docs/KEYBOARD_SHORTCUTS.md with comprehensive keyboard reference
- Add docs/COPYTREE_INTEGRATION.md with accurate profile documentation
- Fix CopyTree profile examples to match implementation (args array)
- Remove non-existent vi-style keybindings from keyboard shortcuts
- Correct Esc key priority order to match actual modal close behavior

## Implementation Notes

**Context & rationale:**
- Complete documentation rewrite from file browser → Worktree Dashboard positioning
- Align README, SPEC, CLAUDE with implemented Worktree Dashboard architecture
- Reflect multi-worktree cards, AI summaries, mood indicators, CopyTree profiles
- Describe dashboard-first navigation (fuzzy search replaces deep tree browsing)

**Implementation details:**
- README.md: Complete rewrite with Worktree Dashboard positioning, new visual ASCII diagram
- SPEC.md: Updated Project Overview, Component Hierarchy, Worktree Dashboard Types sections
- CLAUDE.md: Updated Project Overview, Component Architecture, Custom Hooks, Keyboard Shortcuts
- docs/KEYBOARD_SHORTCUTS.md: New comprehensive keyboard reference (dashboard + tree modes)
- docs/COPYTREE_INTEGRATION.md: New complete guide to CopyTree profiles and usage

## Follow-up Tasks

- Codex review identified and fixed CopyTree profile structure mismatch (docs described rich object, code uses args array)
- Removed non-existent vi-style keybindings (j/k/h/l) from keyboard shortcuts doc
- Corrected Esc key priority order to match actual implementation
- Removed non-existent ai config section from README examples