### PR TITLE
Fix untracked files showing zero line count in worktree cards

### DIFF
--- a/tests/utils/git.test.ts
+++ b/tests/utils/git.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { getGitStatusCached, clearGitStatusCache, stopGitStatusCacheCleanup } from '../../src/utils/git.js';
+import { getGitStatusCached, clearGitStatusCache, stopGitStatusCacheCleanup, getWorktreeChangesWithStats } from '../../src/utils/git.js';
 import type { GitStatus } from '../../src/types/index.js';
 
 // Mock simple-git
@@ -18,10 +18,18 @@ vi.mock('simple-git', () => ({
 	})),
 }));
 
-// Mock fs realpathSync
-vi.mock('fs', () => ({
-	realpathSync: vi.fn((path: string) => path),
-}));
+// Mock fs realpathSync and fs.promises
+// Note: vi.mock is hoisted, so we need to create mocks inside the factory
+vi.mock('fs', async () => {
+	const { vi } = await import('vitest');
+	return {
+		realpathSync: vi.fn((path: string) => path),
+		promises: {
+			readFile: vi.fn(),
+			stat: vi.fn(),
+		},
+	};
+});
 
 describe('git.ts', () => {
 	beforeEach(() => {
@@ -106,6 +114,222 @@ describe('git.ts', () => {
 			// Next call should fetch fresh data (cache miss)
 			const result = await getGitStatusCached(cwd, false);
 			expect(result).toBeInstanceOf(Map);
+		});
+	});
+
+	describe('getWorktreeChangesWithStats - untracked file line counting', () => {
+		let mockReadFile: any;
+		let mockStat: any;
+
+		beforeEach(async () => {
+			clearGitStatusCache();
+			// Get the mocked fs module
+			const fs = await import('fs');
+			mockReadFile = fs.promises.readFile as any;
+			mockStat = fs.promises.stat as any;
+
+			// Reset and setup default behavior
+			vi.mocked(mockReadFile).mockReset();
+			vi.mocked(mockStat).mockReset();
+			vi.mocked(mockStat).mockResolvedValue({ mtimeMs: Date.now() } as any);
+		});
+
+		it('counts lines for untracked files with content', async () => {
+			// Mock simple-git to return untracked file
+			const simpleGit = await import('simple-git');
+			vi.mocked(simpleGit.default).mockReturnValue({
+				status: vi.fn().mockResolvedValue({
+					modified: [],
+					created: [],
+					deleted: [],
+					renamed: [],
+					not_added: ['newfile.ts'],
+					conflicted: [],
+				}),
+				revparse: vi.fn().mockResolvedValue('/mock/repo'),
+				diff: vi.fn().mockResolvedValue(''), // Empty diff for untracked files
+			} as any);
+
+			// Mock file read with 10 lines (each ending with \n)
+			vi.mocked(mockReadFile).mockResolvedValue(Buffer.from('line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n'));
+
+			const result = await getWorktreeChangesWithStats('/mock/repo', true);
+
+			expect(result.changes).toHaveLength(1);
+			const change = result.changes[0];
+			expect(change.status).toBe('untracked');
+			expect(change.insertions).toBe(10); // 10 newlines = 10 lines
+			expect(change.deletions).toBeNull();
+		});
+
+		it('counts empty untracked file as 0 lines', async () => {
+			const simpleGit = await import('simple-git');
+			vi.mocked(simpleGit.default).mockReturnValue({
+				status: vi.fn().mockResolvedValue({
+					modified: [],
+					created: [],
+					deleted: [],
+					renamed: [],
+					not_added: ['empty.ts'],
+					conflicted: [],
+				}),
+				revparse: vi.fn().mockResolvedValue('/mock/repo'),
+				diff: vi.fn().mockResolvedValue(''),
+			} as any);
+
+			// Mock empty file
+			vi.mocked(mockReadFile).mockResolvedValue(Buffer.from(''));
+
+			const result = await getWorktreeChangesWithStats('/mock/repo', true);
+
+			expect(result.changes).toHaveLength(1);
+			const change = result.changes[0];
+			expect(change.status).toBe('untracked');
+			expect(change.insertions).toBe(0);
+			expect(change.deletions).toBeNull();
+		});
+
+		it('handles file read errors gracefully', async () => {
+			const simpleGit = await import('simple-git');
+			vi.mocked(simpleGit.default).mockReturnValue({
+				status: vi.fn().mockResolvedValue({
+					modified: [],
+					created: [],
+					deleted: [],
+					renamed: [],
+					not_added: ['unreadable.bin'],
+					conflicted: [],
+				}),
+				revparse: vi.fn().mockResolvedValue('/mock/repo'),
+				diff: vi.fn().mockResolvedValue(''),
+			} as any);
+
+			// Mock file read failure (e.g., binary file, permission error)
+			vi.mocked(mockReadFile).mockRejectedValue(new Error('EACCES: permission denied'));
+
+			const result = await getWorktreeChangesWithStats('/mock/repo', true);
+
+			expect(result.changes).toHaveLength(1);
+			const change = result.changes[0];
+			expect(change.status).toBe('untracked');
+			expect(change.insertions).toBeNull(); // Should fall back to null
+			expect(change.deletions).toBeNull();
+		});
+
+		it('preserves existing behavior for staged files', async () => {
+			const simpleGit = await import('simple-git');
+			vi.mocked(simpleGit.default).mockReturnValue({
+				status: vi.fn().mockResolvedValue({
+					modified: [],
+					created: ['staged.ts'],
+					deleted: [],
+					renamed: [],
+					not_added: [],
+					conflicted: [],
+				}),
+				revparse: vi.fn().mockResolvedValue('/mock/repo'),
+				// Mock diff output for staged file
+				diff: vi.fn().mockResolvedValue('50\t10\tstaged.ts'),
+			} as any);
+
+			const result = await getWorktreeChangesWithStats('/mock/repo', true);
+
+			expect(result.changes).toHaveLength(1);
+			const change = result.changes[0];
+			expect(change.status).toBe('added');
+			expect(change.insertions).toBe(50); // From git diff, not filesystem
+			expect(change.deletions).toBe(10);
+			// fs.readFile should NOT be called for staged files
+			expect(vi.mocked(mockReadFile)).not.toHaveBeenCalled();
+		});
+
+		it('handles mixed tracked and untracked files correctly', async () => {
+			const simpleGit = await import('simple-git');
+			vi.mocked(simpleGit.default).mockReturnValue({
+				status: vi.fn().mockResolvedValue({
+					modified: ['modified.ts'],
+					created: [],
+					deleted: [],
+					renamed: [],
+					not_added: ['untracked.ts'],
+					conflicted: [],
+				}),
+				revparse: vi.fn().mockResolvedValue('/mock/repo'),
+				diff: vi.fn().mockResolvedValue('30\t5\tmodified.ts'),
+			} as any);
+
+			// Mock file read for untracked file (3 lines with trailing newline)
+			vi.mocked(mockReadFile).mockResolvedValue(Buffer.from('line1\nline2\nline3\n'));
+
+			const result = await getWorktreeChangesWithStats('/mock/repo', true);
+
+			expect(result.changes).toHaveLength(2);
+
+			const modifiedChange = result.changes.find(c => c.path.endsWith('modified.ts'));
+			expect(modifiedChange?.status).toBe('modified');
+			expect(modifiedChange?.insertions).toBe(30);
+			expect(modifiedChange?.deletions).toBe(5);
+
+			const untrackedChange = result.changes.find(c => c.path.endsWith('untracked.ts'));
+			expect(untrackedChange?.status).toBe('untracked');
+			expect(untrackedChange?.insertions).toBe(3); // 3 newlines = 3 lines
+			expect(untrackedChange?.deletions).toBeNull();
+		});
+
+		it('handles file without trailing newline correctly', async () => {
+			const simpleGit = await import('simple-git');
+			vi.mocked(simpleGit.default).mockReturnValue({
+				status: vi.fn().mockResolvedValue({
+					modified: [],
+					created: [],
+					deleted: [],
+					renamed: [],
+					not_added: ['no-trailing-newline.ts'],
+					conflicted: [],
+				}),
+				revparse: vi.fn().mockResolvedValue('/mock/repo'),
+				diff: vi.fn().mockResolvedValue(''),
+			} as any);
+
+			// Mock file without trailing newline (3 lines)
+			vi.mocked(mockReadFile).mockResolvedValue(Buffer.from('line1\nline2\nline3'));
+
+			const result = await getWorktreeChangesWithStats('/mock/repo', true);
+
+			expect(result.changes).toHaveLength(1);
+			const change = result.changes[0];
+			expect(change.status).toBe('untracked');
+			expect(change.insertions).toBe(3); // 2 newlines + 1 for final line = 3 lines
+			expect(change.deletions).toBeNull();
+		});
+
+		it('detects and rejects binary files', async () => {
+			const simpleGit = await import('simple-git');
+			vi.mocked(simpleGit.default).mockReturnValue({
+				status: vi.fn().mockResolvedValue({
+					modified: [],
+					created: [],
+					deleted: [],
+					renamed: [],
+					not_added: ['image.png'],
+					conflicted: [],
+				}),
+				revparse: vi.fn().mockResolvedValue('/mock/repo'),
+				diff: vi.fn().mockResolvedValue(''),
+			} as any);
+
+			// Mock binary file (contains NUL byte)
+			const binaryContent = Buffer.alloc(100);
+			binaryContent[50] = 0; // NUL byte at position 50
+			vi.mocked(mockReadFile).mockResolvedValue(binaryContent);
+
+			const result = await getWorktreeChangesWithStats('/mock/repo', true);
+
+			expect(result.changes).toHaveLength(1);
+			const change = result.changes[0];
+			expect(change.status).toBe('untracked');
+			expect(change.insertions).toBeNull(); // Binary files return null
+			expect(change.deletions).toBeNull();
 		});
 	});
 });


### PR DESCRIPTION
## Summary
This PR fixes untracked files displaying as `+0` in worktree card statistics instead of showing their actual line count. Previously, only staged files (after `git add`) displayed correct insertion counts.

Closes #184

## Changes Made
- Implement countFileLines helper with binary file detection
- Count newlines directly to match git diff --numstat behavior
- Add bounded concurrency (max 10 files) for parallel processing
- Handle edge cases: empty files, no trailing newlines, binary files
- Add comprehensive tests for untracked file line counting
- Graceful error handling for unreadable files

## Implementation Notes

**Context & rationale:**
- Untracked files were showing as `+0` because `git diff --numstat` only tracks staged/modified files
- Added filesystem-based line counting for untracked files to show actual line counts immediately
- Fallback to `null` if file cannot be read (permissions, binary files, etc.)

**Implementation details:**
- Modified `addChange` function in `src/utils/git.ts` to read untracked files from filesystem
- Implemented `countFileLines` helper that:
  - Reads files as Buffer to detect binary content (NUL bytes in first 8KB)
  - Counts newline characters directly to match git diff --numstat behavior
  - Handles files without trailing newlines correctly
  - Returns null for binary files, permission errors, or unreadable files
- Added bounded concurrency (max 10 files) for parallel untracked file processing
- Graceful error handling for edge cases (binary files, race conditions, deleted files)

## Follow-up Tasks
- Performance is optimized with bounded concurrency, but could be further improved with caching for unchanged files if needed
- Binary file detection uses simple NUL byte check - could be enhanced with more sophisticated heuristics if issues arise