### PR TITLE
Add native Finder/Explorer button to worktree cards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { Box, Text, useApp, useInput, useStdout } from 'ink';
 import { Header } from './components/Header.js';
 import { WorktreeOverview, sortWorktrees } from './components/WorktreeOverview.js';
+import { getExplorerLabel } from './components/WorktreeCard.js';
 import { TreeView } from './components/TreeView.js';
 import { ContextMenu } from './components/ContextMenu.js';
 import { WorktreePanel } from './components/WorktreePanel.js';
@@ -476,6 +477,22 @@ const AppContent: React.FC<AppProps> = ({ cwd, config: initialConfig, noWatch, n
       events.emit('ui:notify', { type: 'error', message });
     }
   }, [effectiveConfig, sortedWorktrees]);
+
+  const handleOpenWorktreeExplorer = useCallback(async (id: string) => {
+    const target = sortedWorktrees.find(wt => wt.id === id);
+    if (!target) {
+      return;
+    }
+
+    try {
+      await open(target.path);
+      const label = getExplorerLabel();
+      events.emit('ui:notify', { type: 'success', message: `Opened in ${label}` });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to open folder';
+      events.emit('ui:notify', { type: 'error', message });
+    }
+  }, [sortedWorktrees]);
 
   const handleOpenGitFox = useCallback(async () => {
     try {
@@ -1227,6 +1244,7 @@ const AppContent: React.FC<AppProps> = ({ cwd, config: initialConfig, noWatch, n
               onToggleExpand={handleToggleExpandWorktree}
               onCopyTree={handleCopyTreeForWorktree}
               onOpenEditor={handleOpenWorktreeEditor}
+              onOpenExplorer={handleOpenWorktreeExplorer}
             />
           ) : (
             <TreeView

--- a/src/components/WorktreeCard.tsx
+++ b/src/components/WorktreeCard.tsx
@@ -5,6 +5,17 @@ import { homedir } from 'node:os';
 import type { FileChangeDetail, GitStatus, Worktree, WorktreeChanges, WorktreeMood } from '../types/index.js';
 import { useTheme } from '../theme/ThemeProvider.js';
 
+/**
+ * Get OS-specific file manager label
+ * @returns Label for the current platform's file manager
+ */
+export function getExplorerLabel(): string {
+  const platform = process.platform;
+  if (platform === 'darwin') return 'Finder';
+  if (platform === 'win32') return 'Explorer';
+  return 'Folder'; // Linux/Unix fallback
+}
+
 export interface WorktreeCardProps {
   worktree: Worktree;
   changes: WorktreeChanges;
@@ -16,6 +27,7 @@ export interface WorktreeCardProps {
   onToggleExpand: () => void;
   onCopyTree?: () => void;
   onOpenEditor?: () => void;
+  onOpenExplorer?: () => void;
   registerClickRegion?: (
     id: string,
     bounds?: { x: number; y: number; width: number; height: number },
@@ -196,9 +208,13 @@ export const WorktreeCard: React.FC<WorktreeCardProps> = ({
   onToggleExpand,
   onCopyTree,
   onOpenEditor,
+  onOpenExplorer,
   registerClickRegion,
 }) => {
   const { palette } = useTheme();
+
+  // Memoize explorer label for performance
+  const explorerLabel = useMemo(() => getExplorerLabel(), []);
 
   // Map traffic light state to palette colors
   const trafficColor = useMemo(() => {
@@ -399,6 +415,13 @@ export const WorktreeCard: React.FC<WorktreeCardProps> = ({
           registerRegion={registerClickRegion}
         />
         <Box gap={1}>
+          <ActionButton
+            id={`${worktree.id}-explorer`}
+            label={explorerLabel}
+            color={palette.text.secondary}
+            onPress={onOpenExplorer}
+            registerRegion={registerClickRegion}
+          />
           <ActionButton
             id={`${worktree.id}-copytree`}
             label="CopyTree"

--- a/src/components/WorktreeOverview.tsx
+++ b/src/components/WorktreeOverview.tsx
@@ -16,6 +16,7 @@ export interface WorktreeOverviewProps {
   onToggleExpand: (id: string) => void;
   onCopyTree: (id: string, profile?: string) => void;
   onOpenEditor: (id: string) => void;
+  onOpenExplorer: (id: string) => void;
 }
 
 const MOOD_PRIORITY: Record<WorktreeMood, number> = {
@@ -77,6 +78,7 @@ export const WorktreeOverview: React.FC<WorktreeOverviewProps> = ({
   onToggleExpand,
   onCopyTree,
   onOpenEditor,
+  onOpenExplorer,
 }) => {
   const sorted = useMemo(() => sortWorktrees(worktrees), [worktrees]);
   const start = Math.max(0, visibleStart ?? 0);
@@ -140,9 +142,9 @@ export const WorktreeOverview: React.FC<WorktreeOverviewProps> = ({
             isExpanded={expandedWorktreeIds.has(worktree.id)}
             activeRootPath={activeRootPath}
             onToggleExpand={() => onToggleExpand(worktree.id)}
-            // Future interactive actions
             onCopyTree={() => onCopyTree(worktree.id)}
             onOpenEditor={() => onOpenEditor(worktree.id)}
+            onOpenExplorer={() => onOpenExplorer(worktree.id)}
             registerClickRegion={registerClickRegion}
           />
         );


### PR DESCRIPTION
## Summary

Adds a cross-platform file manager button to worktree cards that opens the worktree folder in Finder (macOS), Explorer (Windows), or the default file manager (Linux). The button label dynamically adapts to the user's operating system.

Closes #185

## Changes Made

- Add getExplorerLabel() helper for OS-specific labels (Finder/Explorer/Folder)
- Add handleOpenWorktreeExplorer callback in App.tsx using open package
- Add onOpenExplorer prop threading through WorktreeOverview to WorktreeCard
- Add ActionButton for file manager between Expand and CopyTree buttons
- Centralize OS detection logic to sync button label and notification message
- Export helper to ensure consistency across UI and handler

## Implementation Notes

**Context & Rationale:**
- Added cross-platform file manager button to worktree cards for quick access to folders in native OS file managers
- Used existing `open` package (v11.0.0) to handle cross-platform folder opening
- Button label dynamically adapts: "Finder" (macOS), "Explorer" (Windows), "Folder" (Linux)
- Positioned between Expand and CopyTree buttons for logical workflow: view details → open in finder → copy files → edit in VS Code

**Implementation Details:**
- Added `getExplorerLabel()` helper in WorktreeCard.tsx to detect OS and return appropriate label
- Memoized label for performance (calculated once per component lifecycle)
- Created `handleOpenWorktreeExplorer` in App.tsx following existing handler patterns
- Handler uses `open()` package to open folder in default file manager
- OS-specific success notifications with proper labels
- Error handling for invalid paths or permission issues
- PropType chain: App.tsx → WorktreeOverview → WorktreeCard for handler flow

**Code Review:**
- Exported getExplorerLabel() helper to ensure button label and notification message stay in sync
- Centralized OS detection logic - reused in both UI and handler
- Fixed label mismatch: Linux now shows "Folder" in both button and success notification
- Validated: TypeScript build passes, React patterns follow existing conventions, prop threading consistent with onCopyTree/onOpenEditor

## Follow-up Tasks

- Could add keyboard shortcut (e.g., 'o' or 'f') in future PR
- Could add to context menu as alternative interaction pattern