### PR TITLE
feat(stats): implement activity-based polling and visual weight for GitHub stats

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -201,13 +201,13 @@ export const Header: React.FC<HeaderProps> = ({
           />
         )}
 
-        {/* GitHub Stats */}
+        {/* GitHub Stats - bright when > 0, dim when 0 */}
         {stats.issueCount !== null && (
           <HeaderButton
             id="header-issues"
             label={`[${stats.issueCount} issues]`}
             color={palette.text.secondary}
-            dimColor={true}
+            dimColor={stats.issueCount === 0}
             onPress={handleOpenIssues}
             registerRegion={registerClickRegion}
           />
@@ -218,7 +218,7 @@ export const Header: React.FC<HeaderProps> = ({
             id="header-prs"
             label={`[${stats.prCount} PRs]`}
             color={palette.text.secondary}
-            dimColor={true}
+            dimColor={stats.prCount === 0}
             onPress={handleOpenPRs}
             registerRegion={registerClickRegion}
           />

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -1,6 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { getCommitCount } from '../utils/git.js';
 import { getIssueCount, getPrCount, checkGitHubCli } from '../utils/github.js';
+import { events } from '../services/events.js';
 
 export interface RepositoryStats {
   commitCount: number;
@@ -9,9 +10,16 @@ export interface RepositoryStats {
   loading: boolean;
 }
 
+// Polling configuration
+const IDLE_POLL_INTERVAL = 5 * 60 * 1000;     // 5 minutes when idle
+const ACTIVE_POLL_INTERVAL = 30 * 1000;        // 30 seconds when active
+const ACTIVE_WINDOW_DURATION = 2 * 60 * 1000;  // Stay "active" for 2 mins after last event
+
 /**
  * Hook to fetch and poll repository stats (commit count, issue count, PR count).
- * Polls every 60 seconds to keep stats fresh without overwhelming the system.
+ * Uses adaptive polling that responds to user activity:
+ * - Active mode (30s): Triggered by file changes or manual refresh
+ * - Idle mode (5min): When no activity for 2 minutes
  *
  * @param cwd - Working directory
  * @param enabled - Whether to enable polling (default: true)
@@ -25,12 +33,22 @@ export function useRepositoryStats(cwd: string, enabled: boolean = true): Reposi
     loading: true,
   });
 
+  const lastActivityRef = useRef<number>(Date.now());
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const isFetchingRef = useRef(false);
+  const isMountedRef = useRef(true);
+  const pendingRefreshRef = useRef(false);
+
+  // Setup polling loop with variable interval
   useEffect(() => {
     if (!enabled) return;
 
-    let isMounted = true;
+    isMountedRef.current = true;
 
     const fetchStats = async () => {
+      if (isFetchingRef.current || !enabled || !isMountedRef.current) return;
+      isFetchingRef.current = true;
+
       try {
         // Run commit count and GitHub CLI check in parallel
         const [commits, hasGh] = await Promise.all([
@@ -49,7 +67,8 @@ export function useRepositoryStats(cwd: string, enabled: boolean = true): Reposi
           ]);
         }
 
-        if (isMounted) {
+        // Only update state if still mounted
+        if (isMountedRef.current) {
           setStats({
             commitCount: commits,
             issueCount: issues,
@@ -59,21 +78,66 @@ export function useRepositoryStats(cwd: string, enabled: boolean = true): Reposi
         }
       } catch (error) {
         // Fail silently for stats - don't disrupt the UI
-        if (isMounted) {
+        if (isMountedRef.current) {
           setStats(s => ({ ...s, loading: false }));
+        }
+      } finally {
+        isFetchingRef.current = false;
+
+        // Handle pending refresh request that came in during fetch
+        if (pendingRefreshRef.current && isMountedRef.current) {
+          pendingRefreshRef.current = false;
+          void fetchStats();
         }
       }
     };
 
-    // Initial fetch
-    fetchStats();
+    const scheduleNext = () => {
+      // Don't schedule if unmounted
+      if (!isMountedRef.current) return;
 
-    // Poll every 60 seconds
-    const interval = setInterval(fetchStats, 60000);
+      const now = Date.now();
+      const timeSinceActivity = now - lastActivityRef.current;
+      const isUserActive = timeSinceActivity < ACTIVE_WINDOW_DURATION;
+
+      const delay = isUserActive ? ACTIVE_POLL_INTERVAL : IDLE_POLL_INTERVAL;
+
+      timerRef.current = setTimeout(() => {
+        if (isMountedRef.current) {
+          void fetchStats().then(scheduleNext);
+        }
+      }, delay);
+    };
+
+    const boostActivity = () => {
+      lastActivityRef.current = Date.now();
+      // If we were deep in idle sleep, let the current timer play out
+      // to avoid spamming on every keystroke save
+    };
+
+    const handleRefresh = () => {
+      lastActivityRef.current = Date.now(); // Reset activity timer
+
+      // If currently fetching, mark that a refresh is pending
+      if (isFetchingRef.current) {
+        pendingRefreshRef.current = true;
+      } else {
+        void fetchStats(); // Force immediate fetch
+      }
+    };
+
+    // Subscribe to events
+    const unsubscribeWatcher = events.on('watcher:change', boostActivity);
+    const unsubscribeRefresh = events.on('sys:refresh', handleRefresh);
+
+    // Initial fetch
+    void fetchStats().then(scheduleNext);
 
     return () => {
-      isMounted = false;
-      clearInterval(interval);
+      isMountedRef.current = false;
+      if (timerRef.current) clearTimeout(timerRef.current);
+      unsubscribeWatcher();
+      unsubscribeRefresh();
     };
   }, [cwd, enabled]);
 

--- a/tests/hooks/useRepositoryStats.test.ts
+++ b/tests/hooks/useRepositoryStats.test.ts
@@ -1,0 +1,260 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor, cleanup } from '@testing-library/react';
+import { useRepositoryStats } from '../../src/hooks/useRepositoryStats.ts';
+import * as gitUtils from '../../src/utils/git.js';
+import * as githubUtils from '../../src/utils/github.js';
+import { events } from '../../src/services/events.js';
+
+vi.mock('../../src/utils/git.js');
+vi.mock('../../src/utils/github.js');
+
+describe('useRepositoryStats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+
+    // Default mocks
+    vi.mocked(gitUtils.getCommitCount).mockResolvedValue(42);
+    vi.mocked(githubUtils.checkGitHubCli).mockResolvedValue(true);
+    vi.mocked(githubUtils.getIssueCount).mockResolvedValue(5);
+    vi.mocked(githubUtils.getPrCount).mockResolvedValue(3);
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  describe('Initial fetch', () => {
+    it('fetches stats on mount', async () => {
+      const { result } = renderHook(() => useRepositoryStats('/test/path'));
+
+      // Initially loading
+      expect(result.current.loading).toBe(true);
+
+      // Let the initial fetch complete
+      await act(async () => {
+        await vi.runOnlyPendingTimersAsync();
+      });
+
+      expect(result.current.loading).toBe(false);
+      expect(result.current.commitCount).toBe(42);
+      expect(result.current.issueCount).toBe(5);
+      expect(result.current.prCount).toBe(3);
+    });
+
+    it('handles GitHub CLI unavailable gracefully', async () => {
+      vi.mocked(githubUtils.checkGitHubCli).mockResolvedValue(false);
+
+      const { result } = renderHook(() => useRepositoryStats('/test/path'));
+
+      await act(async () => {
+        await vi.runOnlyPendingTimersAsync();
+      });
+
+      expect(result.current.loading).toBe(false);
+      expect(result.current.commitCount).toBe(42);
+      expect(result.current.issueCount).toBe(null);
+      expect(result.current.prCount).toBe(null);
+    });
+
+    it('handles fetch errors gracefully', async () => {
+      vi.mocked(gitUtils.getCommitCount).mockRejectedValue(new Error('Git error'));
+
+      const { result } = renderHook(() => useRepositoryStats('/test/path'));
+
+      await act(async () => {
+        await vi.runOnlyPendingTimersAsync();
+      });
+
+      // Should not crash, just mark as not loading
+      expect(result.current.loading).toBe(false);
+    });
+  });
+
+  describe('Adaptive polling', () => {
+    it('uses active interval (30s) when recently active', async () => {
+      const { result } = renderHook(() => useRepositoryStats('/test/path'));
+
+      // Initial fetch
+      await act(async () => {
+        await vi.runOnlyPendingTimersAsync();
+      });
+
+      vi.mocked(gitUtils.getCommitCount).mockClear();
+
+      // Advance 30 seconds (active interval)
+      await act(async () => {
+        vi.advanceTimersByTime(30000);
+        await vi.runOnlyPendingTimersAsync();
+      });
+
+      // Should have fetched again at 30s interval
+      expect(gitUtils.getCommitCount).toHaveBeenCalled();
+    });
+
+    it('continues polling at regular intervals', async () => {
+      const { result } = renderHook(() => useRepositoryStats('/test/path'));
+
+      // Initial fetch
+      await act(async () => {
+        await vi.runOnlyPendingTimersAsync();
+      });
+
+      // Count fetches over time - each 30s interval should trigger
+      const fetchCounts: number[] = [];
+
+      for (let i = 0; i < 4; i++) {
+        vi.mocked(gitUtils.getCommitCount).mockClear();
+        await act(async () => {
+          vi.advanceTimersByTime(30000);
+          await vi.runOnlyPendingTimersAsync();
+        });
+        fetchCounts.push(vi.mocked(gitUtils.getCommitCount).mock.calls.length);
+      }
+
+      // Should have had fetches at each 30s interval (active mode)
+      expect(fetchCounts.every(c => c >= 1)).toBe(true);
+    });
+  });
+
+  describe('Event handling', () => {
+    it('triggers immediate fetch on sys:refresh event', async () => {
+      const { result } = renderHook(() => useRepositoryStats('/test/path'));
+
+      // Initial fetch
+      await act(async () => {
+        await vi.runOnlyPendingTimersAsync();
+      });
+
+      vi.mocked(gitUtils.getCommitCount).mockClear();
+      vi.mocked(gitUtils.getCommitCount).mockResolvedValue(50);
+
+      // Emit refresh event
+      await act(async () => {
+        events.emit('sys:refresh');
+        await vi.runOnlyPendingTimersAsync();
+      });
+
+      // Should have fetched immediately
+      expect(gitUtils.getCommitCount).toHaveBeenCalled();
+      expect(result.current.commitCount).toBe(50);
+    });
+
+    it('boosts activity timestamp on watcher:change event', async () => {
+      const { result } = renderHook(() => useRepositoryStats('/test/path'));
+
+      // Initial fetch
+      await act(async () => {
+        await vi.runOnlyPendingTimersAsync();
+      });
+
+      // Verify initial fetch completed
+      expect(result.current.loading).toBe(false);
+      expect(result.current.commitCount).toBe(42);
+
+      // Emit watcher change to boost activity
+      await act(async () => {
+        events.emit('watcher:change', { type: 'change', path: '/test/file.ts' });
+      });
+
+      // Clear mocks and advance to next poll cycle
+      vi.mocked(gitUtils.getCommitCount).mockClear();
+      vi.mocked(gitUtils.getCommitCount).mockResolvedValue(55);
+
+      await act(async () => {
+        vi.advanceTimersByTime(30000);
+        await vi.runOnlyPendingTimersAsync();
+      });
+
+      // Verify fetch happened (activity boosted so still using active interval)
+      expect(gitUtils.getCommitCount).toHaveBeenCalled();
+      expect(result.current.commitCount).toBe(55);
+    });
+
+    it('handles pending refresh during active fetch', async () => {
+      // Make fetch take time
+      let fetchResolve: () => void;
+      vi.mocked(gitUtils.getCommitCount).mockImplementation(() =>
+        new Promise<number>((resolve) => {
+          fetchResolve = () => resolve(42);
+        })
+      );
+
+      const { result } = renderHook(() => useRepositoryStats('/test/path'));
+
+      // Start initial fetch (pending)
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      // Trigger manual refresh while fetch is pending - should be queued
+      await act(async () => {
+        events.emit('sys:refresh');
+      });
+
+      // Only one fetch should be in progress
+      expect(gitUtils.getCommitCount).toHaveBeenCalledTimes(1);
+
+      // Complete the pending fetch - should trigger the queued refresh
+      vi.mocked(gitUtils.getCommitCount).mockClear();
+      vi.mocked(gitUtils.getCommitCount).mockResolvedValue(50);
+
+      await act(async () => {
+        fetchResolve!();
+        await vi.runOnlyPendingTimersAsync();
+      });
+
+      // The pending refresh should have been executed
+      expect(gitUtils.getCommitCount).toHaveBeenCalled();
+    });
+  });
+
+  describe('Concurrent fetch prevention', () => {
+    it('prevents concurrent fetches', async () => {
+      // Make fetch take time
+      let fetchResolve: () => void;
+      const fetchPromise = new Promise<number>((resolve) => {
+        fetchResolve = () => resolve(42);
+      });
+      vi.mocked(gitUtils.getCommitCount).mockReturnValue(fetchPromise);
+
+      const { result } = renderHook(() => useRepositoryStats('/test/path'));
+
+      // Start initial fetch (pending)
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      // Trigger manual refresh while fetch is pending
+      await act(async () => {
+        events.emit('sys:refresh');
+      });
+
+      // Only one fetch should be in progress
+      expect(gitUtils.getCommitCount).toHaveBeenCalledTimes(1);
+
+      // Complete the pending fetch
+      await act(async () => {
+        fetchResolve!();
+        await vi.runOnlyPendingTimersAsync();
+      });
+    });
+  });
+
+  describe('Enabled flag', () => {
+    it('does not fetch when disabled', async () => {
+      const { result } = renderHook(() => useRepositoryStats('/test/path', false));
+
+      await act(async () => {
+        await vi.runOnlyPendingTimersAsync();
+      });
+
+      // Should not have fetched
+      expect(gitUtils.getCommitCount).not.toHaveBeenCalled();
+      expect(result.current.loading).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements adaptive activity-based polling for GitHub stats and visual weight styling for header buttons. This transforms Canopy from passive polling into an intelligent dashboard that responds to user activity.

Closes #194

## Changes Made

- Replace fixed 60s polling with adaptive intervals (30s active, 5min idle)
- Add isMounted guard to prevent state updates after unmount
- Handle pending refresh requests during active fetch
- Subscribe to `watcher:change` to boost activity timestamp
- Subscribe to `sys:refresh` for immediate fetch on manual refresh (r key)
- Make issue/PR button `dimColor` dynamic based on count values
- Add comprehensive tests for polling logic and event handling

## Implementation Notes

**Context & rationale:**
- Transforms the fixed 60-second polling into activity-based adaptive polling
- Active mode (30s) triggers when file changes or manual refresh happens
- Idle mode (5min) engages after 2 minutes of inactivity
- Visual weight on header buttons helps identify actionable items at a glance

**Implementation details:**
- Replaced `setInterval` with recursive `setTimeout` chain to allow variable delays
- Added `lastActivityRef` to track when last activity occurred
- Added `isFetchingRef` guard to prevent concurrent fetches
- Added `isMountedRef` to prevent state updates after unmount
- Added `pendingRefreshRef` to queue refresh requests during active fetch
- Subscribed to `watcher:change` events to boost activity timestamp
- Subscribed to `sys:refresh` for immediate fetch on manual refresh (r key)
- Updated `dimColor` prop on issue/PR HeaderButtons to be dynamic based on count value
- Commits button remains always dim (informational only per issue spec)

## Follow-up Tasks

- Consider adding visual staleness indicator (loading pulse, "last updated X seconds ago")
- Consider hiding zero-value buttons entirely (issue mentioned as optional enhancement)