### PR TITLE
fix(monitor): serialize git operations and batch React updates for CPU performance

### DIFF
--- a/src/hooks/useWorktreeMonitor.ts
+++ b/src/hooks/useWorktreeMonitor.ts
@@ -1,13 +1,23 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { events } from '../services/events.js';
 import type { WorktreeState } from '../services/monitor/index.js';
 import type { Worktree } from '../types/index.js';
 
 /**
- * Hook to subscribe to WorktreeMonitor updates.
+ * Batch delay for collecting updates before triggering a React render.
+ * This prevents cascade re-renders when multiple worktrees update simultaneously.
+ */
+const BATCH_DELAY_MS = 100;
+
+/**
+ * Hook to subscribe to WorktreeMonitor updates with batching.
  *
  * This hook listens to the global event bus for worktree state updates
  * and maintains a map of worktree states indexed by ID.
+ *
+ * **PERFORMANCE**: Updates are batched over a 100ms window to prevent
+ * excessive React re-renders when multiple worktrees update in quick succession.
+ * This is critical for maintaining low CPU usage with many active worktrees.
  *
  * @returns Map of worktree ID to WorktreeState
  *
@@ -20,32 +30,106 @@ import type { Worktree } from '../types/index.js';
 export function useWorktreeMonitor(): Map<string, WorktreeState> {
   const [states, setStates] = useState<Map<string, WorktreeState>>(new Map());
 
+  // Pending updates that will be flushed after BATCH_DELAY_MS
+  const pendingUpdates = useRef<Map<string, WorktreeState>>(new Map());
+  const pendingRemovals = useRef<Set<string>>(new Set());
+  const flushTimer = useRef<NodeJS.Timeout | null>(null);
+
+  // Track mounted state to prevent post-unmount state updates
+  // This guards against "setState on unmounted component" warnings
+  const isMounted = useRef<boolean>(true);
+
+  /**
+   * Flush pending updates to React state.
+   * This is called after the batch delay expires.
+   */
+  const flushUpdates = useCallback(() => {
+    flushTimer.current = null;
+
+    // Guard against post-unmount updates
+    if (!isMounted.current) {
+      return;
+    }
+
+    const updates = pendingUpdates.current;
+    const removals = pendingRemovals.current;
+
+    // Nothing to flush
+    if (updates.size === 0 && removals.size === 0) {
+      return;
+    }
+
+    setStates(prev => {
+      // Start with previous state
+      const next = new Map(prev);
+
+      // Apply removals first
+      for (const id of removals) {
+        next.delete(id);
+      }
+
+      // Then apply updates
+      for (const [id, state] of updates) {
+        next.set(id, state);
+      }
+
+      // Clear pending queues
+      pendingUpdates.current = new Map();
+      pendingRemovals.current = new Set();
+
+      return next;
+    });
+  }, []);
+
+  /**
+   * Schedule a flush if not already scheduled.
+   * Guards against scheduling after unmount.
+   */
+  const scheduleFlush = useCallback(() => {
+    // Don't schedule if unmounted or already scheduled
+    if (!isMounted.current || flushTimer.current) {
+      return;
+    }
+    flushTimer.current = setTimeout(flushUpdates, BATCH_DELAY_MS);
+  }, [flushUpdates]);
+
   useEffect(() => {
     // Subscribe to worktree update events
     const unsubscribeUpdate = events.on('sys:worktree:update', (newState: WorktreeState) => {
-      setStates(prev => {
-        // Create new Map to trigger React re-render
-        const next = new Map(prev);
-        next.set(newState.id, newState);
-        return next;
-      });
+      // Queue the update instead of immediately updating React state
+      pendingUpdates.current.set(newState.id, newState);
+      // Remove from pending removals if present (update supersedes removal)
+      pendingRemovals.current.delete(newState.id);
+      scheduleFlush();
     });
 
     // Subscribe to worktree removal events
     const unsubscribeRemove = events.on('sys:worktree:remove', ({ worktreeId }) => {
-      setStates(prev => {
-        // Create new Map without the removed worktree
-        const next = new Map(prev);
-        next.delete(worktreeId);
-        return next;
-      });
+      // Queue the removal
+      pendingRemovals.current.add(worktreeId);
+      // Remove from pending updates if present (removal supersedes update)
+      pendingUpdates.current.delete(worktreeId);
+      scheduleFlush();
     });
 
     return () => {
+      // Mark as unmounted FIRST to prevent any in-flight flushes
+      isMounted.current = false;
+
       unsubscribeUpdate();
       unsubscribeRemove();
+
+      // Clear any pending flush on unmount
+      if (flushTimer.current) {
+        clearTimeout(flushTimer.current);
+        flushTimer.current = null;
+      }
+
+      // Clear pending queues to release memory
+      pendingUpdates.current = new Map();
+      pendingRemovals.current = new Set();
     };
-  }, []);
+  }, [scheduleFlush]);
 
   return states;
 }


### PR DESCRIPTION
## Summary

Fixes high CPU usage (80-100%) when monitoring multiple worktrees by implementing three key performance optimizations:

1. **Serial queue for git operations** - Prevents parallel git process spawning
2. **Smart emit filtering** - Skips re-renders when only internal state changes
3. **Batched React updates** - Collects updates over 100ms window before rendering

Closes #199

## Changes Made

- Add serial queue in WorktreeService with master poll timer (max 1 concurrent git process)
- Implement `shouldEmitUpdate()` check in WorktreeMonitor to skip unnecessary re-renders
- Add 100ms batched React updates in useWorktreeMonitor hook
- Increase background worktree poll interval from 10s to 30s
- Disable internal polling timer in `setPollingInterval` (service manages all polling)
- Add `isMounted` guard to prevent post-unmount state updates
- Clean up `lastPollTime` and `pollQueue` entries when monitors are removed
- Update tests to reflect new service-driven polling architecture

## Implementation Notes

### Context & Rationale
- Performance issue causing 80-100% CPU when monitoring multiple worktrees
- Root causes: uncontrolled parallel git spawning, referential instability in React state, excessive timer intervals
- Terminal apps (Ink) are particularly sensitive to re-renders as every render causes full terminal clear and redraw

### 1. Serial Queue in WorktreeService (P0)
- Replaced individual monitor polling timers with a centralized master poll timer
- Git operations now execute serially through a queue (max 1 concurrent git process)
- 50ms delay between queue items to let UI breathe
- Active worktree: polls every 2s, Background worktrees: polls every 30s (increased from 10s)

### 2. Smart Emit in WorktreeMonitor (P0)
- Added `shouldEmitUpdate()` check before emitting events
- Only emits if user-visible fields change: summary, modifiedCount, trafficLight, mood
- Skips unnecessary re-renders when internal state changes (timestamps, etc.)

### 3. Batched React Updates in useWorktreeMonitor (P1)
- Collects updates over 100ms window before triggering React render
- Prevents cascade re-renders when multiple worktrees update simultaneously
- Handles both updates and removals in the same batch

### Technical Changes
- `WorktreeService.ts`: Added `masterPollTimer`, `pollQueue`, `processQueue()`, `scheduleDuePolls()`
- `WorktreeMonitor.ts`: Added `updateGitStatusFromService()`, `shouldEmitUpdate()`, `lastEmittedState`
- `useWorktreeMonitor.ts`: Added `pendingUpdates`, `pendingRemovals`, `flushTimer`, 100ms batching
- Background polling interval increased from 10s to 30s for reduced load

## Follow-up Tasks

- Consider implementing adaptive polling (faster when active, slower when idle)
- Audit remaining timer-based components for potential optimization
- Add performance benchmarks for multi-worktree scenarios