### PR TITLE
perf(render): enable Ink performance optimizations for CPU usage

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -190,7 +190,15 @@ async function main(): Promise<void> {
         noGit: parsedArgs.noGit,
         initialFilter: parsedArgs.initialFilter,
       }),
-      { exitOnCtrlC: false, stdin: supportsRaw ? process.stdin : undefined, stdout: process.stdout }
+      {
+        exitOnCtrlC: false,
+        stdin: supportsRaw ? process.stdin : undefined,
+        stdout: process.stdout,
+        // Performance: Limit render frequency to 5 FPS for responsive UI feedback
+        // while still reducing CPU usage significantly from the default 30 FPS
+        maxFps: 5,
+        incrementalRendering: true,
+      }
     );
 
     await waitUntilExit();


### PR DESCRIPTION
## Summary

Fixes high CPU usage when monitoring multiple worktrees by enabling Ink v6's built-in performance features.

Closes #199

## Changes Made

- Add `maxFps: 5` to limit render frequency (down from default 30 FPS)
- Enable `incrementalRendering` to only redraw changed terminal lines
- Reduces CPU usage during idle periods with multiple worktrees

## Implementation Notes

### Context & Rationale

* Simplified approach using Ink's built-in performance features instead of complex batching/queuing solutions originally proposed in the issue
* Ink v6 provides `maxFps` and `incrementalRendering` options that solve the core problem with minimal code changes
* 5 FPS provides good balance between UI responsiveness and CPU savings

### Technical Details

* Added `maxFps: 5` to Ink render options - limits UI updates to 5 frames per second (200ms intervals)
* Added `incrementalRendering: true` - only redraws changed lines instead of full terminal clear
* This is a 2-line change in `src/cli.ts` that leverages Ink v6's built-in performance features
* No custom batching, queuing, or state management changes required

### Why This Works

The root cause of high CPU usage was excessive terminal re-rendering. Ink's built-in options directly address this:

- **`maxFps: 5`** - Batches state updates and limits renders to 5 per second
- **`incrementalRendering: true`** - Only redraws changed lines instead of clearing and redrawing the entire terminal

## Follow-up Tasks

* Consider making `maxFps` configurable via CLI flag or config file
* Monitor real-world CPU usage to confirm improvement