### PR TITLE
Clean up stale test mocks for deleted hooks

### DIFF
--- a/tests/dashboard.integration.test.tsx
+++ b/tests/dashboard.integration.test.tsx
@@ -87,24 +87,10 @@ vi.mock('../src/hooks/useFileTree.js', () => ({
   })),
 }));
 
-vi.mock('../src/hooks/useMultiWorktreeStatus.ts', () => ({
-  useMultiWorktreeStatus: vi.fn(() => ({
-    worktreeChanges: mockWorktreeChanges,
-    refresh: vi.fn(),
-    clear: vi.fn(),
-  })),
-}));
-
 vi.mock('../src/hooks/useGitStatus.js', () => ({
   useGitStatus: vi.fn(() => ({
     gitStatus: new Map(),
     refresh: vi.fn(),
-  })),
-}));
-
-vi.mock('../src/hooks/useWatcher.js', () => ({
-  useWatcher: vi.fn(() => ({
-    isWatching: false,
   })),
 }));
 

--- a/tests/hooks/useWorktreeSummaries.test.tsx
+++ b/tests/hooks/useWorktreeSummaries.test.tsx
@@ -84,7 +84,7 @@ describe('useWorktreeSummaries Hook', () => {
       vi.advanceTimersByTime(10000);
     });
 
-    // 3. Rerender with NEW OBJECT but SAME DATA (simulating useMultiWorktreeStatus poll)
+    // 3. Rerender with NEW OBJECT but SAME DATA (simulating WorktreeMonitor poll)
     const changes2 = new Map<string, WorktreeChanges>([
       [
         'wt1',


### PR DESCRIPTION
## Summary

Remove stale test mocks that reference deleted hooks (`useMultiWorktreeStatus` and `useWatcher`). These hooks were replaced by the centralized `WorktreeService`/`WorktreeMonitor` architecture but their test mocks remained, creating confusion about the actual codebase structure.

Closes #220

## Changes Made

- Remove `vi.mock` for `useMultiWorktreeStatus` (hook was replaced by `useWorktreeMonitor`)
- Remove `vi.mock` for `useWatcher` (functionality moved to `WorktreeMonitor`)
- Update comment in `useWorktreeSummaries` test to reference `WorktreeMonitor` instead of `useMultiWorktreeStatus`

## Implementation Notes

**Context & rationale:**
* The codebase transitioned from `useMultiWorktreeStatus` and `useWatcher` hooks to centralized `WorktreeService`/`WorktreeMonitor` architecture
* Test mocks for the deleted hooks remained, referencing non-existent files
* Removed stale mocks to maintain accuracy and prevent confusion about actual architecture

**Implementation details:**
* Removed `vi.mock('../src/hooks/useMultiWorktreeStatus.ts', ...)` from `tests/dashboard.integration.test.tsx`
* Removed `vi.mock('../src/hooks/useWatcher.js', ...)` from `tests/dashboard.integration.test.tsx`
* Updated stale comment in `tests/hooks/useWorktreeSummaries.test.tsx` that referenced `useMultiWorktreeStatus poll` to `WorktreeMonitor poll`
* Verified `useGitStatus` mock is still needed (used in `App.tsx` and `useAppLifecycle.ts`)
* Dashboard integration tests pass (22/23, 1 flaky test pre-existing on main)

## Follow-up Tasks

* The flaky test `View Mode Switching > maintains state when switching views` was observed failing intermittently (pre-existing on main)
* Some Vitest worker crashes observed when running tests in isolation (also pre-existing, happens on main)