### PR TITLE
fix(ui): remove ⌘ prefix from command palette shortcut display

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -228,7 +228,7 @@ export function CommandPalette({
               </Text>
               <Text color={palette.text.secondary}>
                 {' '}{command.label}
-                {command.shortcut ? ` [⌘${command.shortcut}]` : ''}
+                {command.shortcut ? ` [${command.shortcut}]` : ''}
               </Text>
               <Box flexGrow={1} />
               <Text color={palette.chrome.border}>{BORDER.vertical}</Text>


### PR DESCRIPTION
## Summary
Fixes the command palette shortcut display to show the correct format. The shortcuts were previously changed to use raw number keys (1-9) without any modifier, but the display still showed the ⌘ prefix.

Closes #217

## Changes Made
- Update shortcut display format from `[⌘N]` to `[N]`
- Aligns display with actual keyboard behavior (raw number keys 1-9)

## Implementation Notes

**Context & rationale:**
- Shortcuts were simplified to raw 1-9 keys in commit a0f90a8
- The `useQuickLinks` hook was updated but display formatting in `CommandPalette.tsx` was not

**Implementation details:**
- Changed line 231 in `CommandPalette.tsx` from `[⌘${command.shortcut}]` to `[${command.shortcut}]`
- Single line change that removes the command key prefix from shortcut display
- Aligns the display with the actual keyboard behavior (raw number keys 1-9)

## Follow-up Tasks
- Note: Main branch has pre-existing build errors related to ProfileSelector removal. These are unrelated to this fix.