### PR TITLE
Fix broken ProfileSelector references from merge conflict

### DIFF
--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -4,11 +4,9 @@ import type { WorktreeState } from './monitor/index.js';
 
 export type ModalId =
   | 'worktree'
-  | 'profile-selector'
   | 'command-palette';
 export interface ModalContextMap {
   worktree: undefined;
-  'profile-selector': { worktreeId?: string };
   'command-palette': undefined;
 }
 


### PR DESCRIPTION
## Summary

Removes broken ProfileSelector references that were left after PR #216 merged with conflicts, causing TypeScript compilation to fail.

Closes #222

## Changes Made

- Remove `onOpenProfileSelector` prop from `useDashboardNav` call
- Remove `p` key handler for profile selector
- Remove `onOpenProfileSelector` from `useKeyboard` call
- Remove ProfileSelector JSX rendering block
- Remove `handleOpenProfileSelector` callback definition
- Remove `handleOpenProfileSelectorForFocused` callback definition
- Remove `handleProfileSelect` callback definition
- Remove `isProfileSelectorOpen` variable
- Remove `'profile-selector'` from `MODAL_CLOSE_PRIORITY` array
- Remove `'profile-selector'` from `ModalId` type and `ModalContextMap` in events.ts

## Implementation Notes

**Context & rationale:**
- PR #216 removed ProfileSelector component but merge conflict resolution left orphaned references
- Critical fix - blocks all builds and development

**Implementation details:**
- Verified: `npm run typecheck` passes
- Verified: `npm run build` succeeds
- Verified: All 845 tests pass

## Breaking Changes & Migration Hints

- None - this is a cleanup of already-removed functionality
- No migration required