### PR TITLE
refactor: remove unused search config and fuzzyMatchMultiple function

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -157,11 +157,6 @@ export interface CanopyConfig {
     folderHeatMap?: boolean; // Enable folder heat coloring (default: true)
     heatMapIntensity?: 'subtle' | 'normal' | 'intense'; // Heat scaling (default: 'normal')
   };
-  search?: {
-    defaultAction?: 'open' | 'copy'; // Action when pressing Enter on search result
-    limit?: number; // Maximum number of search results to show
-    respectGitignore?: boolean; // Whether to respect gitignore in search (inherits from respectGitignore if not set)
-  };
   keys?: KeyMapConfig; // Configurable keyboard shortcuts with preset support
   quickLinks?: QuickLinksConfig; // Quick links to external tools and chat clients
 }
@@ -226,11 +221,6 @@ export const DEFAULT_CONFIG: CanopyConfig = {
     statusStyle: 'glyph',      // Use color-coded glyphs by default
     folderHeatMap: true,       // Enable heat mapping by default
     heatMapIntensity: 'normal', // Normal intensity by default
-  },
-  search: {
-    defaultAction: 'open',     // Open file by default on Enter
-    limit: 20,                 // Show top 20 results
-    respectGitignore: true,    // Respect gitignore by default
   },
   quickLinks: {
     enabled: true,

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -219,19 +219,6 @@ function mergeConfigs(...configs: Partial<CanopyConfig>[]): CanopyConfig {
       }
 
       if (
-        typedKey === 'search' &&
-        value &&
-        typeof value === 'object' &&
-        !Array.isArray(value)
-      ) {
-        merged[typedKey] = {
-          ...merged.search,
-          ...value,
-        } as typeof merged.search;
-        continue;
-      }
-
-      if (
         typedKey === 'quickLinks' &&
         value &&
         typeof value === 'object' &&
@@ -433,23 +420,6 @@ function validateConfig(config: unknown): CanopyConfig {
       }
       if (typeof c.worktrees.showInHeader !== 'boolean') {
         errors.push('config.worktrees.showInHeader must be a boolean');
-      }
-    }
-  }
-
-  // Validate search (optional field)
-  if (c.search !== undefined) {
-    if (!c.search || typeof c.search !== 'object') {
-      errors.push('config.search must be an object');
-    } else {
-      if (c.search.defaultAction !== undefined && !['open', 'copy'].includes(c.search.defaultAction)) {
-        errors.push('config.search.defaultAction must be "open" or "copy"');
-      }
-      if (c.search.limit !== undefined && (typeof c.search.limit !== 'number' || c.search.limit <= 0)) {
-        errors.push('config.search.limit must be a positive number');
-      }
-      if (c.search.respectGitignore !== undefined && typeof c.search.respectGitignore !== 'boolean') {
-        errors.push('config.search.respectGitignore must be a boolean');
       }
     }
   }

--- a/src/utils/fuzzyMatch.ts
+++ b/src/utils/fuzzyMatch.ts
@@ -100,36 +100,3 @@ export function fuzzyMatch(query: string, path: string): FuzzyMatchResult | null
 
   return { path, score, matchIndices };
 }
-
-/**
- * Fuzzy matches a query against multiple paths and returns top results sorted by score.
- *
- * @param query - Search query string
- * @param paths - Array of file paths to search
- * @param limit - Maximum number of results to return (default: 20)
- * @returns Array of match results sorted by score (highest first)
- */
-export function fuzzyMatchMultiple(
-  query: string,
-  paths: string[],
-  limit: number = 20
-): FuzzyMatchResult[] {
-  const results: FuzzyMatchResult[] = [];
-
-  for (const path of paths) {
-    const match = fuzzyMatch(query, path);
-    if (match) {
-      results.push(match);
-    }
-  }
-
-  // Sort by score descending, then by path length ascending (prefer shorter paths)
-  results.sort((a, b) => {
-    if (b.score !== a.score) {
-      return b.score - a.score;
-    }
-    return a.path.length - b.path.length;
-  });
-
-  return results.slice(0, limit);
-}

--- a/tests/dashboard.integration.test.tsx
+++ b/tests/dashboard.integration.test.tsx
@@ -124,9 +124,6 @@ vi.mock('../src/services/fuzzySearch.js', () => ({
     { path: '/test/repo/main/src/App.tsx', relativePath: 'src/App.tsx', type: 'file' },
     { path: '/test/repo/main/package.json', relativePath: 'package.json', type: 'file' },
   ]),
-  fuzzyMatchMultiple: vi.fn((files, query) =>
-    files.filter((f: any) => f.relativePath.toLowerCase().includes(query.toLowerCase()))
-  ),
 }));
 
 import App from '../src/App.js';


### PR DESCRIPTION
## Summary

Removes dead code related to a search feature that was never implemented or was removed in PR #214.

Closes #226

## Changes Made

- Remove `search` block from `CanopyConfig` type
- Remove `search` from `DEFAULT_CONFIG`
- Remove search merging logic from `mergeConfigs()`
- Remove search validation from `validateConfig()`
- Remove `fuzzyMatchMultiple()` function from `fuzzyMatch.ts`
- Remove `fuzzyMatchMultiple` mock from dashboard integration tests

## Implementation Notes

**Context & rationale:**
- `config.search` block is defined but never read by any runtime code
- `fuzzyMatchMultiple()` is exported but never imported by runtime code
- Only `fuzzyMatch()` (single path matching) is actually used by CommandPalette

**Implementation details:**
- Removed `search` block from `CanopyConfig` interface in `src/types/index.ts`
- Removed `search` from `DEFAULT_CONFIG` object in `src/types/index.ts`
- Removed search merging logic from `mergeConfigs()` in `src/utils/config.ts`
- Removed search validation block from `validateConfig()` in `src/utils/config.ts`
- Removed `fuzzyMatchMultiple()` function from `src/utils/fuzzyMatch.ts`
- Removed `fuzzyMatchMultiple` mock from `tests/dashboard.integration.test.tsx`

## Breaking Changes & Migration Hints

**Breaking changes:**
- Removed `search` config option from `CanopyConfig` type (no runtime impact - was never used)

**Migration hints:**
- Users with `search` in their config files will see no change (config was never read)
- No action required - purely dead code removal