### PR TITLE
fix(monitor): handle deleted worktrees gracefully

### DIFF
--- a/src/utils/errorTypes.ts
+++ b/src/utils/errorTypes.ts
@@ -29,6 +29,16 @@ export class GitError extends CanopyError {
 }
 
 /**
+ * Worktree directory no longer exists (deleted externally).
+ * Used to signal that a worktree monitor should stop polling and clean up.
+ */
+export class WorktreeRemovedError extends GitError {
+  constructor(path: string, cause?: Error) {
+    super('Worktree directory no longer exists', { path }, cause);
+  }
+}
+
+/**
  * File system operation failed (permission denied, file not found, read error)
  */
 export class FileSystemError extends CanopyError {


### PR DESCRIPTION
## Summary

Fix for WorktreeMonitor crashing the display when monitoring deleted worktrees. When worktrees are deleted externally (e.g., during automated PR merges), the monitor now gracefully stops polling and emits a removal event instead of flooding stderr with errors.

Closes #233

## Changes Made

- Add `WorktreeRemovedError` class for distinguishing deleted worktrees from other git errors
- Add directory existence check in `getWorktreeChangesWithStats()` before calling `simpleGit()`
- Handle `WorktreeRemovedError` in `WorktreeMonitor.updateGitStatus()` to stop polling and emit `sys:worktree:remove` event
- Add comprehensive tests for deleted worktree scenarios

## Implementation Notes

**Context & rationale:**
- When worktrees are deleted externally (e.g., during automated PR merges), WorktreeMonitor continued polling them, causing `simple-git` to throw errors that flooded stderr and destroyed the terminal display
- Added proactive directory existence check before calling `simpleGit(cwd)` to catch ENOENT early
- Created dedicated `WorktreeRemovedError` class for clear error differentiation
- Monitor now gracefully stops and emits removal event so UI can clean up

**Implementation details:**
- Added `WorktreeRemovedError` class in `src/utils/errorTypes.ts` - extends GitError with path context
- Added `fs.access()` check in `getWorktreeChangesWithStats()` before `simpleGit()` call
- Added error handling in `WorktreeMonitor.updateGitStatus()` that detects `WorktreeRemovedError`, emits `sys:worktree:remove`, and calls `stop()`
- Added comprehensive tests for both the git utility and WorktreeMonitor

## Breaking Changes

None - internal resilience improvement