### PR TITLE
fix(monitor): refresh branch name after git checkout

### DIFF
--- a/src/services/monitor/WorktreeMonitor.ts
+++ b/src/services/monitor/WorktreeMonitor.ts
@@ -163,6 +163,38 @@ export class WorktreeMonitor extends EventEmitter {
     }
   }
 
+  /**
+   * Update metadata (branch, name) from a refreshed worktree object.
+   * This is called by WorktreeService.sync() when worktree metadata changes
+   * (e.g., after a `git checkout` or `git switch` in the worktree).
+   *
+   * Only updates the mutable state object, not the readonly instance properties.
+   * Emits an update event if metadata actually changed.
+   *
+   * @param worktree - Updated worktree data from git worktree list
+   */
+  public updateMetadata(worktree: Worktree): void {
+    const branchChanged = this.state.branch !== worktree.branch;
+    const nameChanged = this.state.name !== worktree.name;
+
+    if (branchChanged || nameChanged) {
+      // Capture old values from state before updating
+      const oldBranch = this.state.branch;
+      const oldName = this.state.name;
+
+      this.state.branch = worktree.branch;
+      this.state.name = worktree.name;
+      logInfo('WorktreeMonitor metadata updated', {
+        id: this.id,
+        oldBranch,
+        newBranch: worktree.branch,
+        oldName,
+        newName: worktree.name,
+      });
+      this.emitUpdate();
+    }
+  }
+
 
   /**
    * Force refresh of git status and AI summary.

--- a/src/services/monitor/WorktreeService.ts
+++ b/src/services/monitor/WorktreeService.ts
@@ -84,6 +84,9 @@ class WorktreeService {
       const isActive = wt.id === activeWorktreeId;
 
       if (existingMonitor) {
+        // Update metadata (branch, name) if changed (e.g., after git checkout)
+        existingMonitor.updateMetadata(wt);
+
         // Update polling interval based on active status
         const interval = isActive
           ? ACTIVE_WORKTREE_INTERVAL_MS

--- a/tests/services/WorktreeMonitor.test.ts
+++ b/tests/services/WorktreeMonitor.test.ts
@@ -629,4 +629,267 @@ describe('WorktreeMonitor - Atomic State Updates', () => {
       expect(stopPollingSpy).toHaveBeenCalled();
     });
   });
+
+  describe('Metadata Update (Branch Refresh)', () => {
+    it('updates state when branch changes', async () => {
+      vi.mocked(gitStatus.getWorktreeChangesWithStats).mockResolvedValue({
+        worktreeId: baseWorktree.id,
+        rootPath: baseWorktree.path,
+        changes: [],
+        changedFileCount: 0,
+        lastUpdated: Date.now(),
+      });
+
+      const monitor = new WorktreeMonitor(baseWorktree);
+      await monitor.start();
+
+      // Simulate a branch change (as if user ran `git checkout new-branch`)
+      const updatedWorktree: Worktree = {
+        ...baseWorktree,
+        branch: 'new-feature-branch',
+        name: 'new-feature-branch',
+      };
+
+      // Call updateMetadata with new worktree data
+      monitor.updateMetadata(updatedWorktree);
+
+      // Verify state was updated
+      const state = monitor.getState();
+      expect(state.branch).toBe('new-feature-branch');
+      expect(state.name).toBe('new-feature-branch');
+
+      await monitor.stop();
+    });
+
+    it('emits update event when branch changes', async () => {
+      vi.mocked(gitStatus.getWorktreeChangesWithStats).mockResolvedValue({
+        worktreeId: baseWorktree.id,
+        rootPath: baseWorktree.path,
+        changes: [],
+        changedFileCount: 0,
+        lastUpdated: Date.now(),
+      });
+
+      const monitor = new WorktreeMonitor(baseWorktree);
+      await monitor.start();
+
+      // Clear previous emissions and track new ones
+      const emittedStates: any[] = [];
+      const handler = (state: any) => {
+        emittedStates.push({ ...state });
+      };
+
+      events.on('sys:worktree:update', handler);
+
+      // Simulate a branch change
+      const updatedWorktree: Worktree = {
+        ...baseWorktree,
+        branch: 'switched-branch',
+        name: 'switched-branch',
+      };
+
+      monitor.updateMetadata(updatedWorktree);
+
+      // Should have emitted an update
+      expect(emittedStates.length).toBe(1);
+      expect(emittedStates[0].branch).toBe('switched-branch');
+      expect(emittedStates[0].name).toBe('switched-branch');
+
+      events.off('sys:worktree:update', handler);
+      await monitor.stop();
+    });
+
+    it('does not emit when branch has not changed', async () => {
+      vi.mocked(gitStatus.getWorktreeChangesWithStats).mockResolvedValue({
+        worktreeId: baseWorktree.id,
+        rootPath: baseWorktree.path,
+        changes: [],
+        changedFileCount: 0,
+        lastUpdated: Date.now(),
+      });
+
+      const monitor = new WorktreeMonitor(baseWorktree);
+      await monitor.start();
+
+      // Clear previous emissions and track new ones
+      const emittedStates: any[] = [];
+      const handler = (state: any) => {
+        emittedStates.push({ ...state });
+      };
+
+      events.on('sys:worktree:update', handler);
+
+      // Call updateMetadata with same branch (no change)
+      const sameWorktree: Worktree = {
+        ...baseWorktree,
+        branch: 'feature-test', // Same as initial
+        name: 'feature-test',   // Same as initial
+      };
+
+      monitor.updateMetadata(sameWorktree);
+
+      // Should NOT emit (no change)
+      expect(emittedStates.length).toBe(0);
+
+      events.off('sys:worktree:update', handler);
+      await monitor.stop();
+    });
+
+    it('handles branch change to detached HEAD (undefined branch)', async () => {
+      vi.mocked(gitStatus.getWorktreeChangesWithStats).mockResolvedValue({
+        worktreeId: baseWorktree.id,
+        rootPath: baseWorktree.path,
+        changes: [],
+        changedFileCount: 0,
+        lastUpdated: Date.now(),
+      });
+
+      const monitor = new WorktreeMonitor(baseWorktree);
+      await monitor.start();
+
+      // Simulate detached HEAD (branch becomes undefined)
+      const detachedWorktree: Worktree = {
+        ...baseWorktree,
+        branch: undefined,
+        name: 'HEAD detached',
+      };
+
+      monitor.updateMetadata(detachedWorktree);
+
+      const state = monitor.getState();
+      expect(state.branch).toBeUndefined();
+      expect(state.name).toBe('HEAD detached');
+
+      await monitor.stop();
+    });
+
+    it('updates only name when branch stays same but name changes', async () => {
+      vi.mocked(gitStatus.getWorktreeChangesWithStats).mockResolvedValue({
+        worktreeId: baseWorktree.id,
+        rootPath: baseWorktree.path,
+        changes: [],
+        changedFileCount: 0,
+        lastUpdated: Date.now(),
+      });
+
+      const monitor = new WorktreeMonitor(baseWorktree);
+      await monitor.start();
+
+      const emittedStates: any[] = [];
+      const handler = (state: any) => {
+        emittedStates.push({ ...state });
+      };
+
+      events.on('sys:worktree:update', handler);
+
+      // Same branch, different name (edge case)
+      const updatedWorktree: Worktree = {
+        ...baseWorktree,
+        branch: 'feature-test', // Same
+        name: 'renamed-worktree', // Different
+      };
+
+      monitor.updateMetadata(updatedWorktree);
+
+      // Should emit because name changed
+      expect(emittedStates.length).toBe(1);
+      expect(emittedStates[0].branch).toBe('feature-test');
+      expect(emittedStates[0].name).toBe('renamed-worktree');
+
+      events.off('sys:worktree:update', handler);
+      await monitor.stop();
+    });
+
+    it('emits when only branch changes but name stays the same', async () => {
+      vi.mocked(gitStatus.getWorktreeChangesWithStats).mockResolvedValue({
+        worktreeId: baseWorktree.id,
+        rootPath: baseWorktree.path,
+        changes: [],
+        changedFileCount: 0,
+        lastUpdated: Date.now(),
+      });
+
+      const monitor = new WorktreeMonitor(baseWorktree);
+      await monitor.start();
+
+      const emittedStates: any[] = [];
+      const handler = (state: any) => {
+        emittedStates.push({ ...state });
+      };
+
+      events.on('sys:worktree:update', handler);
+
+      // Different branch, same name (e.g., worktree name is path-based, not branch-based)
+      const updatedWorktree: Worktree = {
+        ...baseWorktree,
+        branch: 'different-branch', // Different
+        name: 'feature-test', // Same as initial
+      };
+
+      monitor.updateMetadata(updatedWorktree);
+
+      // Should emit because branch changed
+      expect(emittedStates.length).toBe(1);
+      expect(emittedStates[0].branch).toBe('different-branch');
+      expect(emittedStates[0].name).toBe('feature-test');
+
+      events.off('sys:worktree:update', handler);
+      await monitor.stop();
+    });
+
+    it('sequential updates emit only when values actually change', async () => {
+      vi.mocked(gitStatus.getWorktreeChangesWithStats).mockResolvedValue({
+        worktreeId: baseWorktree.id,
+        rootPath: baseWorktree.path,
+        changes: [],
+        changedFileCount: 0,
+        lastUpdated: Date.now(),
+      });
+
+      const monitor = new WorktreeMonitor(baseWorktree);
+      await monitor.start();
+
+      const emittedStates: any[] = [];
+      const handler = (state: any) => {
+        emittedStates.push({ ...state });
+      };
+
+      events.on('sys:worktree:update', handler);
+
+      // First update: change branch
+      monitor.updateMetadata({
+        ...baseWorktree,
+        branch: 'branch-1',
+        name: 'branch-1',
+      });
+      expect(emittedStates.length).toBe(1);
+
+      // Second update: change branch again
+      monitor.updateMetadata({
+        ...baseWorktree,
+        branch: 'branch-2',
+        name: 'branch-2',
+      });
+      expect(emittedStates.length).toBe(2);
+
+      // Third update: same values (should not emit)
+      monitor.updateMetadata({
+        ...baseWorktree,
+        branch: 'branch-2',
+        name: 'branch-2',
+      });
+      expect(emittedStates.length).toBe(2); // Still 2, no new emission
+
+      // Fourth update: change again
+      monitor.updateMetadata({
+        ...baseWorktree,
+        branch: 'branch-3',
+        name: 'branch-3',
+      });
+      expect(emittedStates.length).toBe(3);
+
+      events.off('sys:worktree:update', handler);
+      await monitor.stop();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the bug where the worktree card continues showing the old branch name after running `git checkout` or `git switch` in a worktree. The branch name now updates within the polling interval (2 seconds for active worktree, 10 seconds for background).

Closes #239

## Changes Made

- Add `updateMetadata()` method to `WorktreeMonitor` that updates `state.branch` and `state.name` when worktree metadata changes
- Call `updateMetadata()` from `WorktreeService.sync()` for existing monitors
- Add 7 unit tests covering branch changes, event emission, detached HEAD, name-only changes, branch-only changes, and sequential update behavior

## Implementation Notes

**Context & rationale:**
- The `WorktreeMonitor` class stored `branch` and `name` as readonly instance properties, never updating them after construction
- The `WorktreeService.sync()` method was already receiving updated worktree data (with correct branch info) but only used it to adjust polling intervals
- The fix follows the "propagate existing data" approach from the issue comment—no additional git commands needed since `useAppLifecycle` already polls `git worktree list --porcelain`

**Implementation details:**
- Added `updateMetadata(worktree: Worktree)` method to `WorktreeMonitor` that:
  - Compares current state's `branch` and `name` with incoming worktree data
  - Updates `this.state.branch` and `this.state.name` if they differ
  - Emits an update event to trigger UI refresh
  - Logs the change for debugging
- Modified `WorktreeService.sync()` to call `existingMonitor.updateMetadata(wt)` before setting polling interval
- Added 7 unit tests covering: branch changes, event emission, no-change optimization, detached HEAD handling, name-only changes, branch-only changes, sequential updates

## Follow-up Tasks

- The readonly instance properties (`this.branch`, `this.name`) on `WorktreeMonitor` are now potentially stale after `updateMetadata()` is called—only `this.state.branch/name` are accurate. Could consider removing the instance properties in a future refactor, but they're not exposed publicly.