### PR TITLE
fix(cli): remove unused --config and --debug flags

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,7 +21,6 @@ interface ParsedArgs {
   noWatch: boolean;
   noGit: boolean;
   initialFilter?: string;
-  debug: boolean;
 }
 
 function parseCliArgs(argv: string[]): ParsedArgs {
@@ -34,7 +33,6 @@ function parseCliArgs(argv: string[]): ParsedArgs {
     showVersion: false,
     noWatch: false,
     noGit: false,
-    debug: false,
   };
 
   for (let i = 0; i < args.length; i++) {
@@ -67,10 +65,6 @@ function parseCliArgs(argv: string[]): ParsedArgs {
       result.configOverrides.showGitStatus = true;
       continue;
     }
-    if (arg === '--debug') {
-      result.debug = true;
-      continue;
-    }
     if (arg === '--editor' || arg === '-e') {
       const editor = args[++i];
       if (!editor || editor.startsWith('-')) throw new Error(`--editor requires a value`);
@@ -89,11 +83,6 @@ function parseCliArgs(argv: string[]): ParsedArgs {
       const maxDepth = parseInt(depth, 10);
       if (isNaN(maxDepth) || maxDepth < 0) throw new Error(`--max-depth must be a non-negative number`);
       result.configOverrides.maxDepth = maxDepth;
-      continue;
-    }
-    if (arg === '--config' || arg === '-c') {
-      const configPath = args[++i];
-      if (!configPath || configPath.startsWith('-')) throw new Error(`--config requires a path`);
       continue;
     }
     if (!arg.startsWith('-')) {
@@ -117,12 +106,10 @@ OPTIONS
   -e, --editor <cmd>    Command to open files (default: $EDITOR or code)
   -f, --filter <query>  Initial filter query
   -d, --max-depth <n>   Maximum recursion depth for directory traversal
-  -c, --config <path>   Path to custom configuration file
   -H, --hidden          Show hidden files
   -g, --git             Force enable git status (default: auto)
   --no-git              Disable git status
   --no-watch            Disable file watching
-  --debug               Enable debug logging
   -h, --help            Show this help message
   -v, --version         Show version information
 

--- a/tests/cli/cli_args.test.ts
+++ b/tests/cli/cli_args.test.ts
@@ -127,11 +127,20 @@ describe('CLI argument parsing', () => {
     expect(stderr).toContain('--max-depth must be a non-negative number');
   });
 
-  it('errors when --config has no value', async () => {
-    const { stderr, exitCode } = await runCli(['--config']);
+  it('errors on removed --config flag', async () => {
+    const { stderr, exitCode } = await runCli(['--config', 'some-path']);
 
     expect(exitCode).toBe(1);
-    expect(stderr).toContain('--config requires a path');
+    expect(stderr).toContain('Unknown flag');
+    expect(stderr).toContain('--config');
+  });
+
+  it('errors on removed --debug flag', async () => {
+    const { stderr, exitCode } = await runCli(['--debug']);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('Unknown flag');
+    expect(stderr).toContain('--debug');
   });
 
   it('accepts short alias -e for --editor', async () => {
@@ -155,11 +164,12 @@ describe('CLI argument parsing', () => {
     expect(stderr).toContain('--max-depth requires a number');
   });
 
-  it('accepts short alias -c for --config', async () => {
-    const { stderr, exitCode } = await runCli(['-c']);
+  it('errors on removed -c flag (was --config)', async () => {
+    const { stderr, exitCode } = await runCli(['-c', 'some-path']);
 
     expect(exitCode).toBe(1);
-    expect(stderr).toContain('--config requires a path');
+    expect(stderr).toContain('Unknown flag');
+    expect(stderr).toContain('-c');
   });
 });
 


### PR DESCRIPTION
## Summary

Removes the `--config` and `--debug` CLI flags which were parsed but never wired up to any functionality, as documented in issue #244.

Closes #244

## Changes Made

- Remove `--config`/`-c` flag parsing that was never connected to `loadConfig()`
- Remove `--debug` flag parsing that was never read after parsing  
- Remove both flags from CLI help text
- Update tests to verify removed flags are now rejected as unknown

## Implementation Notes

**Context & rationale:**
- Both flags were parsed but never wired up to functionality
- `--config` was consumed but `loadConfig()` always used `parsedArgs.cwd` instead
- `--debug` set a value but debug logging is controlled by environment variables
- Removing these flags simplifies the CLI and avoids misleading users

**Implementation details:**
- Removed `--config` parsing block
- Removed `--debug` parsing block
- Removed `debug` field from `ParsedArgs` interface
- Removed both flags from help text

## Breaking Changes & Migration Hints

**Breaking changes:**
- Users who were passing `--config` or `--debug` will now see "Unknown flag" errors
- This is intentional - the flags never worked anyway

**Migration hints:**
- For debug functionality, use environment variables: `CANOPY_DEBUG_EVENTS=1`, `DEBUG_AI_STATUS=1`, `DEBUG_IDENTITY=1`