### PR TITLE
fix(monitor): respect --no-watch flag to disable WorktreeMonitor polling

### DIFF
--- a/src/services/monitor/WorktreeService.ts
+++ b/src/services/monitor/WorktreeService.ts
@@ -106,8 +106,14 @@ class WorktreeService {
 
         monitor.setPollingInterval(interval);
 
-        // Start monitoring
-        await monitor.start();
+        // Start monitoring only if watching is enabled
+        // When --no-watch is passed, we only do initial status fetch
+        if (this.watchingEnabled) {
+          await monitor.start();
+        } else {
+          // Just fetch initial status without starting polling
+          await monitor.fetchInitialStatus();
+        }
 
         this.monitors.set(wt.id, monitor);
       }

--- a/tests/services/WorktreeService.test.ts
+++ b/tests/services/WorktreeService.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import type { Worktree } from '../../src/types/index.js';
+
+// Create a mock class that can be instantiated
+class MockWorktreeMonitor {
+  id: string;
+  path: string;
+  start = vi.fn().mockResolvedValue(undefined);
+  stop = vi.fn().mockResolvedValue(undefined);
+  fetchInitialStatus = vi.fn().mockResolvedValue(undefined);
+  setPollingInterval = vi.fn();
+  updateMetadata = vi.fn();
+  refresh = vi.fn().mockResolvedValue(undefined);
+
+  constructor(worktree: Worktree) {
+    this.id = worktree.id;
+    this.path = worktree.path;
+  }
+
+  getState() {
+    return {
+      id: this.id,
+      path: this.path,
+      name: 'test',
+      branch: 'test',
+      isCurrent: true,
+      worktreeId: this.id,
+      worktreeChanges: null,
+      mood: 'stable',
+      summary: 'Test summary',
+      summaryLoading: false,
+      modifiedCount: 0,
+      changes: [],
+      lastActivityTimestamp: null,
+    };
+  }
+}
+
+// Store created instances
+const mockInstances: MockWorktreeMonitor[] = [];
+
+// Mock WorktreeMonitor with a proper class
+vi.mock('../../src/services/monitor/WorktreeMonitor.js', () => {
+  return {
+    WorktreeMonitor: class {
+      id: string;
+      path: string;
+      start = vi.fn().mockResolvedValue(undefined);
+      stop = vi.fn().mockResolvedValue(undefined);
+      fetchInitialStatus = vi.fn().mockResolvedValue(undefined);
+      setPollingInterval = vi.fn();
+      updateMetadata = vi.fn();
+      refresh = vi.fn().mockResolvedValue(undefined);
+
+      constructor(worktree: Worktree) {
+        this.id = worktree.id;
+        this.path = worktree.path;
+        mockInstances.push(this as unknown as MockWorktreeMonitor);
+      }
+
+      getState() {
+        return {
+          id: this.id,
+          path: this.path,
+          name: 'test',
+          branch: 'test',
+          isCurrent: true,
+          worktreeId: this.id,
+          worktreeChanges: null,
+          mood: 'stable',
+          summary: 'Test summary',
+          summaryLoading: false,
+          modifiedCount: 0,
+          changes: [],
+          lastActivityTimestamp: null,
+        };
+      }
+    },
+  };
+});
+
+// Mock logger
+vi.mock('../../src/utils/logger.js', () => ({
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+  logError: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+const baseWorktree: Worktree = {
+  id: '/test/worktree',
+  path: '/test/worktree',
+  name: 'feature-test',
+  branch: 'feature-test',
+  isCurrent: true,
+};
+
+const secondWorktree: Worktree = {
+  id: '/test/worktree-2',
+  path: '/test/worktree-2',
+  name: 'feature-2',
+  branch: 'feature-2',
+  isCurrent: false,
+};
+
+describe('WorktreeService - watchingEnabled parameter', () => {
+  let worktreeService: any;
+
+  beforeEach(async () => {
+    // Clear mock instances
+    mockInstances.length = 0;
+    vi.clearAllMocks();
+
+    // Re-import to get fresh service instance
+    vi.resetModules();
+    const module = await import('../../src/services/monitor/WorktreeService.js');
+    worktreeService = module.worktreeService;
+  });
+
+  afterEach(async () => {
+    if (worktreeService) {
+      await worktreeService.stopAll();
+    }
+    vi.clearAllMocks();
+  });
+
+  describe('sync() with watchingEnabled=true', () => {
+    it('calls monitor.start() when watchingEnabled is true', async () => {
+      await worktreeService.sync([baseWorktree], baseWorktree.id, 'main', true);
+
+      expect(mockInstances.length).toBe(1);
+      const instance = mockInstances[0];
+      expect(instance.start).toHaveBeenCalled();
+      expect(instance.fetchInitialStatus).not.toHaveBeenCalled();
+    });
+
+    it('starts polling for all worktrees when watchingEnabled is true', async () => {
+      await worktreeService.sync([baseWorktree, secondWorktree], baseWorktree.id, 'main', true);
+
+      expect(mockInstances.length).toBe(2);
+
+      for (const instance of mockInstances) {
+        expect(instance.start).toHaveBeenCalled();
+        expect(instance.fetchInitialStatus).not.toHaveBeenCalled();
+      }
+    });
+  });
+
+  describe('sync() with watchingEnabled=false (--no-watch mode)', () => {
+    it('calls monitor.fetchInitialStatus() when watchingEnabled is false', async () => {
+      await worktreeService.sync([baseWorktree], baseWorktree.id, 'main', false);
+
+      expect(mockInstances.length).toBe(1);
+      const instance = mockInstances[0];
+      expect(instance.start).not.toHaveBeenCalled();
+      expect(instance.fetchInitialStatus).toHaveBeenCalled();
+    });
+
+    it('fetches initial status for all worktrees when watchingEnabled is false', async () => {
+      await worktreeService.sync([baseWorktree, secondWorktree], baseWorktree.id, 'main', false);
+
+      expect(mockInstances.length).toBe(2);
+
+      for (const instance of mockInstances) {
+        expect(instance.start).not.toHaveBeenCalled();
+        expect(instance.fetchInitialStatus).toHaveBeenCalled();
+      }
+    });
+
+    it('still sets polling interval even in no-watch mode', async () => {
+      await worktreeService.sync([baseWorktree], baseWorktree.id, 'main', false);
+
+      const instance = mockInstances[0];
+      expect(instance.setPollingInterval).toHaveBeenCalled();
+    });
+  });
+
+  describe('refresh() works regardless of watchingEnabled', () => {
+    it('allows manual refresh when watchingEnabled is true', async () => {
+      await worktreeService.sync([baseWorktree], baseWorktree.id, 'main', true);
+
+      // refresh() should work
+      await expect(worktreeService.refresh()).resolves.not.toThrow();
+    });
+
+    it('allows manual refresh when watchingEnabled is false', async () => {
+      await worktreeService.sync([baseWorktree], baseWorktree.id, 'main', false);
+
+      // refresh() should still work (this is how 'r' key works)
+      await expect(worktreeService.refresh()).resolves.not.toThrow();
+    });
+  });
+
+  describe('existing monitors behavior on watchingEnabled change', () => {
+    it('does not restart existing monitors when watchingEnabled changes', async () => {
+      // First sync with watching enabled
+      await worktreeService.sync([baseWorktree], baseWorktree.id, 'main', true);
+
+      expect(mockInstances.length).toBe(1);
+      const firstInstance = mockInstances[0];
+      const firstStartCallCount = firstInstance.start.mock.calls.length;
+
+      // Second sync with same worktree but watching disabled
+      await worktreeService.sync([baseWorktree], baseWorktree.id, 'main', false);
+
+      // Should not create a new monitor for existing worktree
+      // (existing monitors are updated, not recreated)
+      expect(mockInstances.length).toBe(1);
+
+      // start() should not be called again for existing monitor
+      expect(firstInstance.start.mock.calls.length).toBe(firstStartCallCount);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the `--no-watch` CLI flag which was being parsed but never actually used. Users passing `--no-watch` were still seeing git polling every 2-10 seconds instead of a static dashboard.

Closes #245

## Changes Made

- Add `fetchInitialStatus()` method to `WorktreeMonitor` for one-time git status fetch
- Add `pollingEnabled` flag to track if polling should be active
- Update `WorktreeService.sync()` to call `fetchInitialStatus()` when `watchingEnabled=false`
- Prevent `setPollingInterval()` from restarting polling when `pollingEnabled` is false
- Add comprehensive tests for `--no-watch` behavior and re-sync edge cases
- Add `WorktreeService` test suite for `sync()` with `watchingEnabled` parameter

## Implementation Notes

**Context & rationale:**
- The `--no-watch` flag was being parsed and passed through but never actually used
- `WorktreeService.sync()` stored `watchingEnabled` but always called `monitor.start()` regardless
- Option A from the issue was implemented: make `watchingEnabled` control polling behavior

**Implementation details:**
- Added `fetchInitialStatus()` method to `WorktreeMonitor` - fetches git status once without starting polling
- Added `pollingEnabled` flag to `WorktreeMonitor` to track if polling should be active:
  - `start()` sets `pollingEnabled = true`
  - `fetchInitialStatus()` sets `pollingEnabled = false`
  - `setPollingInterval()` now checks both `isRunning` AND `pollingEnabled` before restarting polling
- Modified `WorktreeService.sync()` to check `watchingEnabled` before starting monitors:
  - When `watchingEnabled=true`: calls `monitor.start()` (existing behavior with polling)
  - When `watchingEnabled=false`: calls `monitor.fetchInitialStatus()` (one-time fetch)
- Manual refresh via 'r' key still works in both modes (calls `monitor.refresh()`)
- **Critical fix from review**: `setPollingInterval()` was previously restarting polling on re-sync even with `--no-watch`; now it respects the `pollingEnabled` flag

## Breaking Changes & Migration

- **None** - this is a bug fix that makes an existing flag work as documented
- Existing users of `--no-watch` will now get the expected behavior