### PR TITLE
Update CLI help and package description to reflect dashboard identity

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-**Canopy** is a terminal-based file browser built with **Ink** (React for CLIs). It is designed for developers working with AI agents, providing a persistent "vantage point" over the codebase.
+**Canopy** is a **Worktree Context Dashboard** built with **Ink** (React for CLIs). It's designed for developers working with AI agents across multiple git worktrees, providing real-time visibility into what's changing, AI-powered activity summaries, and one-keystroke context extraction via CopyTree profiles.
 
 **Key Features:**
 - **Live File Watching:** Real-time updates using `chokidar`.

--- a/docs/KEYBOARD_SHORTCUTS.md
+++ b/docs/KEYBOARD_SHORTCUTS.md
@@ -61,7 +61,7 @@ Canopy launches in Dashboard mode by default, displaying a vertical stack of wor
 
 ## Legacy Tree Mode
 
-Displays traditional hierarchical file browser.
+Displays traditional hierarchical file tree view.
 
 ### Navigation
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gpriday/canopy",
   "version": "0.1.0",
-  "description": "Terminal-based file browser built with ink for developers working with AI agents",
+  "description": "Worktree context dashboard for developers working with AI agents",
   "type": "module",
   "main": "./dist/index.js",
   "bin": {
@@ -25,7 +25,8 @@
   "keywords": [
     "terminal",
     "cli",
-    "file-browser",
+    "worktree",
+    "dashboard",
     "tree",
     "ink",
     "copytree",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -108,7 +108,7 @@ function parseCliArgs(argv: string[]): ParsedArgs {
 
 function showHelp(): void {
   const helpText = `
-Canopy - Terminal-based file browser for developers
+Canopy - Worktree context dashboard for AI-assisted development
 
 USAGE
   canopy [path] [options]
@@ -127,11 +127,11 @@ OPTIONS
   -v, --version         Show version information
 
 ARGS
-  [path]                Directory to browse (default: current directory)
+  [path]                Worktree or directory to monitor (default: current directory)
 
 EXAMPLES
-  canopy                    # Open current directory
-  canopy src                # Open src directory
+  canopy                    # Monitor current directory
+  canopy ~/projects/app     # Monitor specific project
   canopy -f "test"          # Filter for files matching "test"
   canopy -H                 # Show hidden files
   canopy --editor vim       # Use vim to open files


### PR DESCRIPTION
## Summary

Updates all user-facing text to consistently describe Canopy as a "Worktree Context Dashboard" rather than a "terminal-based file browser", aligning with the project's evolution and the source-of-truth description in CLAUDE.md.

Closes #247

## Changes Made

- Update `package.json` description to "Worktree context dashboard for developers working with AI agents"
- Replace "file-browser" keyword with "worktree" and "dashboard" keywords
- Update CLI help header to "Worktree context dashboard for AI-assisted development"
- Update CLI ARGS description from "Directory to browse" to "Worktree or directory to monitor"
- Update CLI examples to use dashboard-centric language ("Monitor" vs "Open")
- Update `GEMINI.md` project overview to match `CLAUDE.md` messaging
- Change "file browser" to "file tree view" in `docs/KEYBOARD_SHORTCUTS.md` for legacy mode

## Implementation Notes

**Context & rationale:**
- Canopy has evolved from a "terminal-based file browser" to a "Worktree Context Dashboard"
- User-facing text needs to reflect this evolution for clarity

**Implementation details:**
- Updated `package.json` description from "Terminal-based file browser" to "Worktree context dashboard"
- Updated `package.json` keywords: replaced "file-browser" with "worktree" and "dashboard"
- Updated CLI help text (`src/cli.ts`) to "Worktree context dashboard for AI-assisted development"
- Updated `GEMINI.md` project overview to match `CLAUDE.md` messaging (dashboard identity)
- Updated `docs/KEYBOARD_SHORTCUTS.md` "file browser" reference to "file tree view" (more accurate for legacy mode)
- Left intentional "Not File Browser" references in CLAUDE.md and README.md that explain the dashboard vs old paradigm

## Breaking Changes

None - this is a messaging/documentation change only. No code behavior changes.