### PR TITLE
feat(config): make polling and AI debounce intervals configurable

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -300,10 +300,12 @@ const AppContent: React.FC<AppProps> = ({ cwd, config: initialConfig, noWatch, n
         worktrees,
         activeWorktreeId,
         'main', // mainBranch - could be made configurable
-        !noWatch
+        !noWatch,
+        config.monitor,
+        config.ai
       );
     }
-  }, [worktrees, activeWorktreeId, lifecycleStatus, noWatch]);
+  }, [worktrees, activeWorktreeId, lifecycleStatus, noWatch, config.monitor, config.ai]);
 
   // Teardown Effect: Clean up all monitors only on unmount
   // This runs once when the component unmounts, not on every dependency change

--- a/src/services/monitor/WorktreeService.ts
+++ b/src/services/monitor/WorktreeService.ts
@@ -1,10 +1,13 @@
 import { WorktreeMonitor, type WorktreeState } from './WorktreeMonitor.js';
-import type { Worktree } from '../../types/index.js';
+import type { Worktree, MonitorConfig, AIConfig } from '../../types/index.js';
+import { DEFAULT_CONFIG } from '../../types/index.js';
 import { logInfo, logWarn } from '../../utils/logger.js';
 import { events } from '../events.js';
 
-const ACTIVE_WORKTREE_INTERVAL_MS = 2000; // 2s for active worktree (fast polling since no file watcher)
-const BACKGROUND_WORKTREE_INTERVAL_MS = 10000; // 10s for background worktrees
+// Default polling intervals (used when config is not provided)
+const DEFAULT_ACTIVE_WORKTREE_INTERVAL_MS = DEFAULT_CONFIG.monitor?.pollIntervalActive ?? 2000;
+const DEFAULT_BACKGROUND_WORKTREE_INTERVAL_MS = DEFAULT_CONFIG.monitor?.pollIntervalBackground ?? 10000;
+const DEFAULT_AI_DEBOUNCE_MS = DEFAULT_CONFIG.ai?.summaryDebounceMs ?? 10000;
 
 /**
  * WorktreeService manages all WorktreeMonitor instances.
@@ -22,6 +25,8 @@ interface PendingSyncRequest {
   activeWorktreeId: string | null;
   mainBranch: string;
   watchingEnabled: boolean;
+  monitorConfig?: MonitorConfig;
+  aiConfig?: AIConfig;
 }
 
 class WorktreeService {
@@ -31,6 +36,9 @@ class WorktreeService {
   private activeWorktreeId: string | null = null;
   private isSyncing: boolean = false;
   private pendingSync: PendingSyncRequest | null = null;
+  private pollIntervalActive: number = DEFAULT_ACTIVE_WORKTREE_INTERVAL_MS;
+  private pollIntervalBackground: number = DEFAULT_BACKGROUND_WORKTREE_INTERVAL_MS;
+  private aiDebounceMs: number = DEFAULT_AI_DEBOUNCE_MS;
 
   /**
    * Initialize or update monitors to match the current worktree list.
@@ -44,17 +52,21 @@ class WorktreeService {
    * @param activeWorktreeId - ID of the currently active worktree
    * @param mainBranch - Main branch name (default: 'main')
    * @param watchingEnabled - Enable file watching (default: true)
+   * @param monitorConfig - Optional polling interval configuration
+   * @param aiConfig - Optional AI summary debounce configuration
    */
   public async sync(
     worktrees: Worktree[],
     activeWorktreeId: string | null = null,
     mainBranch: string = 'main',
-    watchingEnabled: boolean = true
+    watchingEnabled: boolean = true,
+    monitorConfig?: MonitorConfig,
+    aiConfig?: AIConfig
   ): Promise<void> {
     // If already syncing, queue this request and return
     if (this.isSyncing) {
       logWarn('Sync already in progress, queuing request');
-      this.pendingSync = { worktrees, activeWorktreeId, mainBranch, watchingEnabled };
+      this.pendingSync = { worktrees, activeWorktreeId, mainBranch, watchingEnabled, monitorConfig, aiConfig };
       return;
     }
 
@@ -64,6 +76,19 @@ class WorktreeService {
       this.mainBranch = mainBranch;
       this.watchingEnabled = watchingEnabled;
       this.activeWorktreeId = activeWorktreeId;
+
+      // Update polling intervals from config
+      if (monitorConfig?.pollIntervalActive !== undefined) {
+        this.pollIntervalActive = monitorConfig.pollIntervalActive;
+      }
+      if (monitorConfig?.pollIntervalBackground !== undefined) {
+        this.pollIntervalBackground = monitorConfig.pollIntervalBackground;
+      }
+
+      // Update AI debounce from config
+      if (aiConfig?.summaryDebounceMs !== undefined) {
+        this.aiDebounceMs = aiConfig.summaryDebounceMs;
+      }
 
       const currentIds = new Set(worktrees.map(wt => wt.id));
 
@@ -89,10 +114,13 @@ class WorktreeService {
 
         // Update polling interval based on active status
         const interval = isActive
-          ? ACTIVE_WORKTREE_INTERVAL_MS
-          : BACKGROUND_WORKTREE_INTERVAL_MS;
+          ? this.pollIntervalActive
+          : this.pollIntervalBackground;
 
         existingMonitor.setPollingInterval(interval);
+
+        // Update AI debounce
+        existingMonitor.setAIBufferDelay(this.aiDebounceMs);
       } else {
         // Create new monitor
         logInfo('Creating new WorktreeMonitor', { id: wt.id, path: wt.path });
@@ -101,10 +129,13 @@ class WorktreeService {
 
         // Set initial polling interval
         const interval = isActive
-          ? ACTIVE_WORKTREE_INTERVAL_MS
-          : BACKGROUND_WORKTREE_INTERVAL_MS;
+          ? this.pollIntervalActive
+          : this.pollIntervalBackground;
 
         monitor.setPollingInterval(interval);
+
+        // Set AI debounce
+        monitor.setAIBufferDelay(this.aiDebounceMs);
 
         // Start monitoring
         await monitor.start();
@@ -130,7 +161,9 @@ class WorktreeService {
           pending.worktrees,
           pending.activeWorktreeId,
           pending.mainBranch,
-          pending.watchingEnabled
+          pending.watchingEnabled,
+          pending.monitorConfig,
+          pending.aiConfig
         );
       }
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -131,6 +131,25 @@ export interface QuickLinksConfig {
   links: QuickLink[];
 }
 
+/**
+ * Configuration for worktree monitor polling intervals.
+ * Allows tuning for large monorepos or resource-constrained environments.
+ */
+export interface MonitorConfig {
+  /** Polling interval for active worktree in ms (default: 2000, min: 500, max: 60000) */
+  pollIntervalActive?: number;
+  /** Polling interval for background worktrees in ms (default: 10000, min: 5000, max: 300000) */
+  pollIntervalBackground?: number;
+}
+
+/**
+ * Configuration for AI-powered features.
+ */
+export interface AIConfig {
+  /** Debounce interval for AI summary generation in ms (default: 10000, min: 1000, max: 60000) */
+  summaryDebounceMs?: number;
+}
+
 export interface CanopyConfig {
   editor: string;
   editorArgs: string[];
@@ -176,6 +195,8 @@ export interface CanopyConfig {
     autoStart?: boolean;  // Auto-start servers on Canopy launch (default: false)
     enabled?: boolean;    // Enable/disable dev server feature (default: false, must be explicitly enabled)
   };
+  monitor?: MonitorConfig; // Worktree monitor polling intervals
+  ai?: AIConfig; // AI feature configuration
 }
 
 export const DEFAULT_CONFIG: CanopyConfig = {
@@ -235,5 +256,12 @@ export const DEFAULT_CONFIG: CanopyConfig = {
     enabled: false,       // Disabled by default - must be explicitly enabled in project config
     autoStart: false,     // Don't auto-start servers
     // command: undefined - auto-detect from package.json
+  },
+  monitor: {
+    pollIntervalActive: 2000,     // 2s for active worktree
+    pollIntervalBackground: 10000, // 10s for background worktrees
+  },
+  ai: {
+    summaryDebounceMs: 10000, // 10s debounce for AI calls
   },
 };

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -231,6 +231,32 @@ function mergeConfigs(...configs: Partial<CanopyConfig>[]): CanopyConfig {
         continue;
       }
 
+      if (
+        typedKey === 'monitor' &&
+        value &&
+        typeof value === 'object' &&
+        !Array.isArray(value)
+      ) {
+        merged[typedKey] = {
+          ...merged.monitor,
+          ...value,
+        } as typeof merged.monitor;
+        continue;
+      }
+
+      if (
+        typedKey === 'ai' &&
+        value &&
+        typeof value === 'object' &&
+        !Array.isArray(value)
+      ) {
+        merged[typedKey] = {
+          ...merged.ai,
+          ...value,
+        } as typeof merged.ai;
+        continue;
+      }
+
       (merged as any)[typedKey] = value;
     }
   }
@@ -514,6 +540,53 @@ function validateConfig(config: unknown): CanopyConfig {
               usedCommands.add(link.command);
             }
           }
+        }
+      }
+    }
+  }
+
+  // Validate monitor config (optional field)
+  if (c.monitor !== undefined) {
+    if (!c.monitor || typeof c.monitor !== 'object' || Array.isArray(c.monitor)) {
+      errors.push('config.monitor must be an object');
+    } else {
+      // Validate pollIntervalActive (optional, min: 500, max: 60000)
+      if (c.monitor.pollIntervalActive !== undefined) {
+        if (typeof c.monitor.pollIntervalActive !== 'number') {
+          errors.push('config.monitor.pollIntervalActive must be a number');
+        } else if (c.monitor.pollIntervalActive < 500) {
+          errors.push('config.monitor.pollIntervalActive must be at least 500ms');
+        } else if (c.monitor.pollIntervalActive > 60000) {
+          errors.push('config.monitor.pollIntervalActive must be at most 60000ms');
+        }
+      }
+
+      // Validate pollIntervalBackground (optional, min: 5000, max: 300000)
+      if (c.monitor.pollIntervalBackground !== undefined) {
+        if (typeof c.monitor.pollIntervalBackground !== 'number') {
+          errors.push('config.monitor.pollIntervalBackground must be a number');
+        } else if (c.monitor.pollIntervalBackground < 5000) {
+          errors.push('config.monitor.pollIntervalBackground must be at least 5000ms');
+        } else if (c.monitor.pollIntervalBackground > 300000) {
+          errors.push('config.monitor.pollIntervalBackground must be at most 300000ms');
+        }
+      }
+    }
+  }
+
+  // Validate ai config (optional field)
+  if (c.ai !== undefined) {
+    if (!c.ai || typeof c.ai !== 'object' || Array.isArray(c.ai)) {
+      errors.push('config.ai must be an object');
+    } else {
+      // Validate summaryDebounceMs (optional, min: 1000, max: 60000)
+      if (c.ai.summaryDebounceMs !== undefined) {
+        if (typeof c.ai.summaryDebounceMs !== 'number') {
+          errors.push('config.ai.summaryDebounceMs must be a number');
+        } else if (c.ai.summaryDebounceMs < 1000) {
+          errors.push('config.ai.summaryDebounceMs must be at least 1000ms');
+        } else if (c.ai.summaryDebounceMs > 60000) {
+          errors.push('config.ai.summaryDebounceMs must be at most 60000ms');
         }
       }
     }


### PR DESCRIPTION
## Summary

Allow users to configure key timing intervals for git polling and AI summarization via `.canopy.json`. This enables tuning for large monorepos or resource-constrained environments.

Closes #248

## Changes Made

- Add `MonitorConfig` interface for `pollIntervalActive` (500-60000ms) and `pollIntervalBackground` (5000-300000ms)
- Add `AIConfig` interface for `summaryDebounceMs` (1000-60000ms)
- Extend `CanopyConfig` and `DEFAULT_CONFIG` with `monitor` and `ai` sections
- Add deep-merge logic in `config.ts` for `monitor` and `ai` objects
- Add validation with min/max bounds and array rejection
- Update `WorktreeService.sync()` to accept and propagate config
- Update `WorktreeMonitor` to use configurable `aiBufferDelay`
- Cancel/reschedule pending AI timer when debounce changes mid-run
- Pass `config.monitor` and `config.ai` from `App.tsx` to `worktreeService`
- Add 32 new config validation tests covering all edge cases

## Implementation Notes

**Context & rationale:**
- Allow users to configure timing intervals for git polling and AI summarization
- Large monorepos or resource-constrained environments need tunable values

**Implementation details:**
- Added `MonitorConfig` and `AIConfig` interfaces to `src/types/index.ts`
- Added defaults in `DEFAULT_CONFIG` (2s active, 10s background, 10s AI debounce)
- Extended `mergeConfigs()` to deep-merge `monitor` and `ai` config objects
- Added validation rules in `validateConfig()`:
  - `pollIntervalActive`: 500ms - 60000ms
  - `pollIntervalBackground`: 5000ms - 300000ms
  - `summaryDebounceMs`: 1000ms - 60000ms
- Modified `WorktreeService.sync()` to accept `MonitorConfig` and `AIConfig`
- Modified `WorktreeMonitor` to use configurable `aiBufferDelay` instead of hardcoded constant
- Updated `App.tsx` to pass `config.monitor` and `config.ai` to `worktreeService.sync()`

## Breaking Changes & Migration Hints

- **None** - all new config options with sensible defaults
- No migration required - existing behavior unchanged when config not provided

## Example Configuration

```json
{
  "monitor": {
    "pollIntervalActive": 5000,
    "pollIntervalBackground": 30000
  },
  "ai": {
    "summaryDebounceMs": 15000
  }
}
```