### PR TITLE
feat(hooks): add centralized useTerminalDimensions hook

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { Box, Text, useInput, useStdout } from 'ink';
+import { Box, Text, useInput } from 'ink';
 import { useTheme } from '../theme/ThemeProvider.js';
 import type { SlashCommand } from '../hooks/useQuickLinks.js';
 import { fuzzyMatch } from '../utils/fuzzyMatch.js';
@@ -11,6 +11,8 @@ interface CommandPaletteProps {
   commands: SlashCommand[];
   onExecute: (command: SlashCommand) => void;
   onClose: () => void;
+  /** Terminal width for responsive layout (from useTerminalDimensions) */
+  terminalWidth: number;
 }
 
 export function CommandPalette({
@@ -18,14 +20,11 @@ export function CommandPalette({
   commands,
   onExecute,
   onClose,
+  terminalWidth,
 }: CommandPaletteProps): React.JSX.Element | null {
   const { palette } = useTheme();
-  const { stdout } = useStdout();
   const [query, setQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
-
-  // Get terminal width for full-width overlay
-  const terminalWidth = stdout?.columns || 80;
 
   // Filter and sort commands based on query
   const filteredCommands = useMemo(() => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useLayoutEffect } from 'react';
-import { Box, Text, useStdout } from 'ink';
+import { Box, Text } from 'ink';
 import Gradient from 'ink-gradient';
 import { measureElement } from 'ink';
 import type { ProjectIdentity } from '../services/ai/index.js';
@@ -19,6 +19,8 @@ interface HeaderProps {
   commandPaletteOpen?: boolean;
   /** Aggregated AI status across all worktrees */
   aiStatus?: AISummaryStatus;
+  /** Terminal width for responsive layout (from useTerminalDimensions) */
+  terminalWidth: number;
 }
 
 const HeaderButton: React.FC<{
@@ -140,11 +142,10 @@ export const Header: React.FC<HeaderProps> = ({
   onOpenGitFox,
   commandPaletteOpen = false,
   aiStatus,
+  terminalWidth,
 }) => {
   const { palette } = useTheme();
-  const { stdout } = useStdout();
   const stats = useRepositoryStats(cwd);
-  const terminalWidth = stdout?.columns || 80;
 
   const gradient = {
     start: identity.gradientStart,

--- a/src/hooks/useTerminalDimensions.ts
+++ b/src/hooks/useTerminalDimensions.ts
@@ -1,0 +1,137 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useStdout } from 'ink';
+import { events } from '../services/events.js';
+import type { TerminalDimensions } from '../types/index.js';
+
+// Re-export for convenience
+export type { TerminalDimensions } from '../types/index.js';
+
+/** Default dimensions when stdout is unavailable */
+const DEFAULT_DIMENSIONS: TerminalDimensions = {
+  width: 80,
+  height: 24,
+};
+
+/** Minimum dimensions to prevent layout breakage */
+const MIN_DIMENSIONS: TerminalDimensions = {
+  width: 40,
+  height: 10,
+};
+
+/** Default debounce delay in milliseconds */
+const DEFAULT_DEBOUNCE_MS = 50;
+
+interface UseTerminalDimensionsOptions {
+  /** Debounce delay for resize events (default: 50ms) */
+  debounceMs?: number;
+  /** Emit sys:terminal:resize events (default: true) */
+  emitEvents?: boolean;
+}
+
+/**
+ * Hook for reactive terminal dimensions with debouncing and event emission.
+ *
+ * Features:
+ * - Provides reactive `{ width, height }` values
+ * - Debounces resize events to prevent excessive re-renders
+ * - Enforces minimum dimensions to prevent layout breakage
+ * - Emits `sys:terminal:resize` events for components that need resize notifications
+ * - Reserves 1 row from height to prevent scroll jitter on the last line
+ *
+ * @param options Configuration options
+ * @returns Current terminal dimensions
+ */
+export function useTerminalDimensions(
+  options: UseTerminalDimensionsOptions = {}
+): TerminalDimensions {
+  const { debounceMs = DEFAULT_DEBOUNCE_MS, emitEvents = true } = options;
+  const { stdout } = useStdout();
+
+  // Get initial dimensions from stdout or use defaults
+  const getInitialDimensions = useCallback((): TerminalDimensions => {
+    if (!stdout) {
+      return DEFAULT_DIMENSIONS;
+    }
+
+    return {
+      width: Math.max(MIN_DIMENSIONS.width, stdout.columns || DEFAULT_DIMENSIONS.width),
+      // Reserve 1 row for scroll jitter prevention
+      height: Math.max(MIN_DIMENSIONS.height, (stdout.rows || DEFAULT_DIMENSIONS.height) - 1),
+    };
+  }, [stdout]);
+
+  const [dimensions, setDimensions] = useState<TerminalDimensions>(getInitialDimensions);
+
+  // Track debounce timer for cleanup
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Handle resize events with debouncing
+  useEffect(() => {
+    if (!stdout) {
+      return;
+    }
+
+    const handleResize = () => {
+      // Clear any pending debounce timer
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+
+      // Debounce the resize handling
+      debounceTimerRef.current = setTimeout(() => {
+        const newDimensions: TerminalDimensions = {
+          width: Math.max(MIN_DIMENSIONS.width, stdout.columns || DEFAULT_DIMENSIONS.width),
+          // Reserve 1 row for scroll jitter prevention
+          height: Math.max(MIN_DIMENSIONS.height, (stdout.rows || DEFAULT_DIMENSIONS.height) - 1),
+        };
+
+        setDimensions(newDimensions);
+
+        // Emit event for other components that need to respond to resize
+        if (emitEvents) {
+          events.emit('sys:terminal:resize', newDimensions);
+        }
+
+        debounceTimerRef.current = null;
+      }, debounceMs);
+    };
+
+    // Subscribe to resize events
+    stdout.on('resize', handleResize);
+
+    // Cleanup
+    return () => {
+      stdout.off('resize', handleResize);
+
+      // Clear any pending debounce timer
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+    };
+  }, [stdout, debounceMs, emitEvents]);
+
+  // Update dimensions if stdout becomes available
+  useEffect(() => {
+    if (stdout) {
+      const initialDimensions = getInitialDimensions();
+      setDimensions(initialDimensions);
+    }
+  }, [stdout, getInitialDimensions]);
+
+  return dimensions;
+}
+
+/**
+ * Hook for subscribing to terminal resize events without managing dimensions state.
+ * Useful for components that only need to react to resize events.
+ *
+ * @param callback Function to call when terminal is resized
+ */
+export function useTerminalResizeEvent(
+  callback: (dimensions: TerminalDimensions) => void
+): void {
+  useEffect(() => {
+    return events.on('sys:terminal:resize', callback);
+  }, [callback]);
+}

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import type { NotificationPayload, DevServerState } from '../types/index.js';
+import type { NotificationPayload, DevServerState, TerminalDimensions } from '../types/index.js';
 import type { WorktreeState } from './monitor/index.js';
 
 export type ModalId =
@@ -51,6 +51,7 @@ export type CanopyEventMap = {
   'sys:refresh': void;
   'sys:quit': void;
   'sys:config:reload': void;
+  'sys:terminal:resize': TerminalDimensions;
 
   'file:open': { path: string };
   'file:copy-tree': CopyTreePayload;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,16 @@
 export type GitStatus = 'modified' | 'added' | 'deleted' | 'untracked' | 'ignored' | 'renamed';
 
+/**
+ * Terminal dimensions with width and height.
+ * Used for reactive terminal resize handling.
+ */
+export interface TerminalDimensions {
+  /** Terminal width in columns */
+  width: number;
+  /** Terminal height in rows */
+  height: number;
+}
+
 export type NotificationType = 'info' | 'success' | 'error' | 'warning';
 
 export interface FileChangeDetail {

--- a/tests/components/Header.test.tsx
+++ b/tests/components/Header.test.tsx
@@ -3,7 +3,6 @@ import { render } from 'ink-testing-library';
 import { describe, it, expect } from 'vitest';
 import { ThemeProvider } from '../../src/theme/ThemeProvider.js';
 import { Header } from '../../src/components/Header.js';
-import { DEFAULT_CONFIG } from '../../src/types/index.js';
 import type { ProjectIdentity } from '../../src/services/ai/index.js';
 
 describe('Header', () => {
@@ -29,7 +28,7 @@ describe('Header', () => {
         filterActive={false}
         filterQuery=""
         identity={mockIdentity}
-        config={DEFAULT_CONFIG}
+        terminalWidth={80}
       />
     );
 
@@ -45,7 +44,7 @@ describe('Header', () => {
         filterActive={true}
         filterQuery=".ts"
         identity={mockIdentity}
-        config={DEFAULT_CONFIG}
+        terminalWidth={80}
       />
     );
 
@@ -60,9 +59,8 @@ describe('Header', () => {
         cwd="/Users/dev/project"
         filterActive={false}
         filterQuery=""
-        worktreeCount={3}
         identity={mockIdentity}
-        config={DEFAULT_CONFIG}
+        terminalWidth={120}
       />
     );
 
@@ -79,8 +77,7 @@ describe('Header', () => {
         filterActive={false}
         filterQuery=""
         identity={mockIdentity}
-        config={DEFAULT_CONFIG}
-        gitOnlyMode={true}
+        terminalWidth={80}
       />
     );
 

--- a/tests/hooks/useTerminalDimensions.test.tsx
+++ b/tests/hooks/useTerminalDimensions.test.tsx
@@ -1,0 +1,247 @@
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Box, Text } from 'ink';
+import { useTerminalDimensions, useTerminalResizeEvent } from '../../src/hooks/useTerminalDimensions.js';
+import type { TerminalDimensions } from '../../src/types/index.js';
+import { events } from '../../src/services/events.js';
+
+// Mock useStdout from Ink
+vi.mock('ink', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('ink')>();
+  return {
+    ...actual,
+    useStdout: vi.fn(),
+  };
+});
+
+import { useStdout } from 'ink';
+
+// Test component that uses the hook and displays dimensions
+function TestComponent({ options = {} }: { options?: Parameters<typeof useTerminalDimensions>[0] }) {
+  const dimensions = useTerminalDimensions(options);
+  return (
+    <Box>
+      <Text>Width: {dimensions.width}, Height: {dimensions.height}</Text>
+    </Box>
+  );
+}
+
+// Test component for resize event hook
+function ResizeEventComponent({ callback }: { callback: (dimensions: TerminalDimensions) => void }) {
+  useTerminalResizeEvent(callback);
+  return (
+    <Box>
+      <Text>Listening for resize events</Text>
+    </Box>
+  );
+}
+
+describe('useTerminalDimensions', () => {
+  let mockStdout: {
+    columns: number;
+    rows: number;
+    on: ReturnType<typeof vi.fn>;
+    off: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockStdout = {
+      columns: 120,
+      rows: 40,
+      on: vi.fn(),
+      off: vi.fn(),
+    };
+    vi.mocked(useStdout).mockReturnValue({ stdout: mockStdout as any, write: vi.fn() });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    events.removeAllListeners();
+  });
+
+  it('returns initial dimensions from stdout', () => {
+    const { lastFrame } = render(<TestComponent />);
+
+    // Height should be reduced by 1 for scroll jitter prevention
+    expect(lastFrame()).toContain('Width: 120');
+    expect(lastFrame()).toContain('Height: 39');
+  });
+
+  it('returns default dimensions when stdout is unavailable', () => {
+    vi.mocked(useStdout).mockReturnValue({ stdout: null as any, write: vi.fn() });
+
+    const { lastFrame } = render(<TestComponent />);
+
+    expect(lastFrame()).toContain('Width: 80');
+    expect(lastFrame()).toContain('Height: 24');
+  });
+
+  it('enforces minimum dimensions', () => {
+    mockStdout.columns = 20; // Below minimum of 40
+    mockStdout.rows = 5; // Below minimum of 10
+
+    const { lastFrame } = render(<TestComponent />);
+
+    expect(lastFrame()).toContain('Width: 40');
+    expect(lastFrame()).toContain('Height: 10');
+  });
+
+  it('subscribes to resize events', () => {
+    render(<TestComponent />);
+
+    expect(mockStdout.on).toHaveBeenCalledWith('resize', expect.any(Function));
+  });
+
+  it('unsubscribes from resize events on unmount', () => {
+    const { unmount } = render(<TestComponent />);
+
+    unmount();
+
+    expect(mockStdout.off).toHaveBeenCalledWith('resize', expect.any(Function));
+  });
+
+  it('debounces resize events', async () => {
+    const { lastFrame, rerender } = render(<TestComponent />);
+
+    // Get the resize handler
+    const resizeHandler = mockStdout.on.mock.calls[0][1];
+
+    // Simulate resize
+    mockStdout.columns = 100;
+    mockStdout.rows = 30;
+
+    resizeHandler();
+
+    // Dimensions should not have changed yet (debounce active)
+    expect(lastFrame()).toContain('Width: 120');
+
+    // Fast-forward past the debounce period
+    vi.advanceTimersByTime(60);
+
+    // Trigger rerender to reflect state changes
+    rerender(<TestComponent />);
+
+    // Now dimensions should be updated
+    expect(lastFrame()).toContain('Width: 100');
+    expect(lastFrame()).toContain('Height: 29'); // rows - 1
+  });
+
+  it('emits sys:terminal:resize event after debounce', async () => {
+    const eventSpy = vi.fn();
+    events.on('sys:terminal:resize', eventSpy);
+
+    render(<TestComponent />);
+
+    // Get the resize handler
+    const resizeHandler = mockStdout.on.mock.calls[0][1];
+
+    // Simulate resize
+    mockStdout.columns = 100;
+    mockStdout.rows = 30;
+
+    resizeHandler();
+
+    // Event should not have been emitted yet (debounce active)
+    expect(eventSpy).not.toHaveBeenCalled();
+
+    // Fast-forward past the debounce period
+    vi.advanceTimersByTime(60);
+
+    // Event should now be emitted
+    expect(eventSpy).toHaveBeenCalledWith({ width: 100, height: 29 });
+  });
+
+  it('does not emit events when emitEvents is false', async () => {
+    const eventSpy = vi.fn();
+    events.on('sys:terminal:resize', eventSpy);
+
+    render(<TestComponent options={{ emitEvents: false }} />);
+
+    // Get the resize handler
+    const resizeHandler = mockStdout.on.mock.calls[0][1];
+
+    // Simulate resize
+    mockStdout.columns = 100;
+    mockStdout.rows = 30;
+
+    resizeHandler();
+    vi.advanceTimersByTime(60);
+
+    // Event should not have been emitted
+    expect(eventSpy).not.toHaveBeenCalled();
+  });
+
+  it('clears debounce timer on rapid resize events', async () => {
+    const { lastFrame, rerender } = render(<TestComponent />);
+
+    const resizeHandler = mockStdout.on.mock.calls[0][1];
+
+    // First resize
+    mockStdout.columns = 100;
+    mockStdout.rows = 30;
+    resizeHandler();
+
+    // Wait a bit but not past debounce
+    vi.advanceTimersByTime(30);
+
+    // Second resize (should reset the debounce)
+    mockStdout.columns = 80;
+    mockStdout.rows = 25;
+    resizeHandler();
+
+    // Wait past the original debounce time
+    vi.advanceTimersByTime(30);
+    rerender(<TestComponent />);
+
+    // Should still not have updated (new debounce still active)
+    expect(lastFrame()).toContain('Width: 120');
+
+    // Wait for the new debounce to complete
+    vi.advanceTimersByTime(30);
+    rerender(<TestComponent />);
+
+    // Now should have the latest values
+    expect(lastFrame()).toContain('Width: 80');
+    expect(lastFrame()).toContain('Height: 24'); // 25 - 1
+  });
+});
+
+describe('useTerminalResizeEvent', () => {
+  beforeEach(() => {
+    events.removeAllListeners();
+    vi.mocked(useStdout).mockReturnValue({
+      stdout: { columns: 80, rows: 24, on: vi.fn(), off: vi.fn() } as any,
+      write: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    events.removeAllListeners();
+  });
+
+  it('subscribes to sys:terminal:resize events', () => {
+    const callback = vi.fn();
+
+    render(<ResizeEventComponent callback={callback} />);
+
+    // Emit a resize event
+    events.emit('sys:terminal:resize', { width: 100, height: 30 });
+
+    expect(callback).toHaveBeenCalledWith({ width: 100, height: 30 });
+  });
+
+  it('unsubscribes on unmount', () => {
+    const callback = vi.fn();
+
+    const { unmount } = render(<ResizeEventComponent callback={callback} />);
+    unmount();
+
+    // Emit a resize event after unmount
+    events.emit('sys:terminal:resize', { width: 100, height: 30 });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Add centralized `useTerminalDimensions` hook replacing fragmented resize handling across App.tsx, Header, and CommandPalette
- Implement 50ms debouncing to prevent excessive re-renders during rapid resize sequences
- Emit `sys:terminal:resize` events via event bus for components needing resize notifications without managing state

## Changes

- **New**: `src/hooks/useTerminalDimensions.ts` - centralized hook with debouncing, min dimensions (40x10), and scroll jitter prevention
- **New**: `tests/hooks/useTerminalDimensions.test.tsx` - comprehensive tests for dimensions, debouncing, and events
- **Modified**: `src/App.tsx` - uses hook instead of inline resize handler
- **Modified**: `src/components/Header.tsx` and `CommandPalette.tsx` - receive `terminalWidth` prop
- **Modified**: `src/types/index.ts` - added `TerminalDimensions` interface
- **Modified**: `src/services/events.ts` - added `sys:terminal:resize` event type

## Test plan

- [x] All existing tests pass
- [x] New hook tests cover initial dimensions, defaults, minimum enforcement, debouncing, event emission, and cleanup
- [ ] Manual testing of resize behavior in terminal

Closes #259