### PR TITLE
feat(scroll): add mouse wheel scrolling for worktree viewport

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -927,7 +927,7 @@ const AppContent: React.FC<AppProps> = ({ cwd, config: initialConfig, noWatch, n
     };
   }, [sortedWorktrees, devServerEnabled]);
 
-  const { visibleStart, visibleEnd } = useDashboardNav({
+  const { visibleStart, visibleEnd, handleScroll } = useDashboardNav({
     worktrees: sortedWorktrees,
     focusedWorktreeId,
     expandedWorktreeIds,
@@ -1052,6 +1052,7 @@ const AppContent: React.FC<AppProps> = ({ cwd, config: initialConfig, noWatch, n
             onOpenEditor={handleOpenWorktreeEditor}
             onOpenExplorer={handleOpenWorktreeExplorer}
             devServerConfig={devServerConfig}
+            onScroll={anyModalOpen ? undefined : handleScroll}
           />
         </Box>
         {isWorktreePanelOpen && (


### PR DESCRIPTION
## Summary

Implements scrollable viewport functionality for WorktreeOverview when worktree cards exceed terminal height. Users can now scroll through worktree cards using the mouse wheel, with visual indicators showing how many cards are hidden above or below the current viewport.

Closes #265

## Changes Made

- Add `handleScroll` function to `useDashboardNav` with boundary clamping
- Wire `wheel-up`/`wheel-down` events to viewport scroll in `WorktreeOverview`
- Add visual indicators showing "X more worktrees above/below" viewport
- Implement 50ms throttling to prevent jitter from rapid wheel events
- Disable scroll when modals are open for consistent UX

## Implementation Notes

**Context & rationale:**
- Worktree cards with expanded content (AI summaries, file changes, dev servers) can exceed terminal height
- Users need mouse wheel scrolling to navigate when content overflows
- Implemented Option A from issue (enhanced item-based windowing) for simplicity

**Implementation details:**
- Added `handleScroll` function to `useDashboardNav` hook with:
  - Direction-based scrolling ('up'/'down')
  - Boundary clamping to prevent over-scroll
  - 50ms throttling to prevent jitter from rapid wheel events
- Wired mouse wheel events (`wheel-up`/`wheel-down`) in `WorktreeOverview`
- Added visual scroll indicators showing "X more worktrees above/below"
- Modal-aware: scroll is disabled when any modal is open

## Follow-up Tasks

- Consider making throttle interval configurable if 50ms doesn't feel right on all platforms
- Could enhance to pixel-based virtual scrolling (Option B) for smoother UX in future