### PR TITLE
Fix undefined summary string in emitUpdate debug logging

### DIFF
--- a/src/services/monitor/WorktreeMonitor.ts
+++ b/src/services/monitor/WorktreeMonitor.ts
@@ -892,7 +892,7 @@ export class WorktreeMonitor extends EventEmitter {
     const state = this.getState();
     logDebug('emitUpdate called', {
       id: this.id,
-      summary: state.summary?.substring(0, 50) + '...',
+      summary: state.summary ? `${state.summary.substring(0, 50)}...` : undefined,
       modifiedCount: state.modifiedCount,
       mood: state.mood,
       stack: new Error().stack?.split('\n').slice(2, 5).join(' <- ')


### PR DESCRIPTION
## Summary
Fixes incorrect string output in debug logs when worktree summary is undefined.

Closes #279

## Changes Made
- Use conditional expression instead of optional chaining with concatenation
- Return `undefined` when summary is missing, not the misleading string `'undefined...'`
- Debug logs now show proper `undefined` value when there's no summary