### PR TITLE
Fix useAppLifecycle test mocks to match InitialState interface

### DIFF
--- a/tests/hooks/useAppLifecycle.test.ts
+++ b/tests/hooks/useAppLifecycle.test.ts
@@ -19,8 +19,7 @@ describe('useAppLifecycle', () => {
     // Default mock for loadInitialState - returns minimal state
     vi.mocked(state.loadInitialState).mockResolvedValue({
       worktree: null,
-      selectedPath: null,
-      expandedFolders: new Set<string>(),
+      lastCopyProfile: 'default',
     });
   });
 
@@ -129,8 +128,7 @@ describe('useAppLifecycle', () => {
     // Mock loadInitialState to return current worktree
     vi.mocked(state.loadInitialState).mockResolvedValue({
       worktree: mockWorktrees[0],
-      selectedPath: null,
-      expandedFolders: new Set<string>(),
+      lastCopyProfile: 'default',
     });
 
     const { result } = renderHook(() =>
@@ -158,8 +156,7 @@ describe('useAppLifecycle', () => {
     // Mock loadInitialState to return first worktree
     vi.mocked(state.loadInitialState).mockResolvedValue({
       worktree: mockWorktrees[0],
-      selectedPath: null,
-      expandedFolders: new Set<string>(),
+      lastCopyProfile: 'default',
     });
 
     const { result } = renderHook(() =>


### PR DESCRIPTION
## Summary
Updates test mocks in `useAppLifecycle.test.ts` to match the current `InitialState` interface, which no longer includes `selectedPath` and `expandedFolders` properties.

Closes #280

## Changes Made
- Replace obsolete `selectedPath`/`expandedFolders` properties with `lastCopyProfile` in test mocks
- Update `beforeEach` default mock to use correct interface shape
- Fix mocks in "sets active worktree" and "defaults to first worktree" tests