### PR TITLE
Route remaining console.* calls through logger utilities

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -532,7 +532,7 @@ const AppContent: React.FC<AppProps> = ({ cwd, config: initialConfig, noWatch, n
           lastCopyProfile,
           timestamp: Date.now(),
         }).catch((err) => {
-          console.error('Error saving session state:', err);
+          logError('Error saving session state', err);
         });
       }
     };
@@ -836,13 +836,13 @@ const AppContent: React.FC<AppProps> = ({ cwd, config: initialConfig, noWatch, n
         lastCopyProfile,
         timestamp: Date.now(),
       }).catch((err) => {
-        console.error('Error saving session state on quit:', err);
+        logError('Error saving session state on quit', err);
       });
     }
 
     // Stop all running dev servers gracefully
     await devServerManager.stopAll().catch((err) => {
-      console.error('Error stopping dev servers on quit:', err);
+      logError('Error stopping dev servers on quit', err);
     });
 
     // PERF: Removed clearGitStatus() - WorktreeService cleans up on stopAll()

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -167,6 +167,7 @@ async function main(): Promise<void> {
 
     const supportsRaw = Boolean(process.stdin && (process.stdin as any).isTTY && typeof (process.stdin as any).setRawMode === 'function');
     if (!supportsRaw) {
+      // User-facing error message - use console.error directly
       console.error('Raw mode is not supported in this environment. Cannot start interactive UI.');
       process.exit(1);
     }
@@ -204,6 +205,7 @@ async function main(): Promise<void> {
 
   } catch (error) {
     if (error instanceof Error) {
+      // User-facing error message - use console.error directly
       console.error(`Error: ${error.message}`);
       process.exit(1);
     }

--- a/src/components/AppErrorBoundary.tsx
+++ b/src/components/AppErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import React, { Component, ReactNode } from 'react';
 import { Box, Text } from 'ink';
+import { logError } from '../utils/logger.js';
 
 interface AppErrorBoundaryProps {
   children: ReactNode;
@@ -43,9 +44,8 @@ export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorB
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    // Log to console for debugging
-    console.error('Error caught by AppErrorBoundary:', error);
-    console.error('Component stack:', errorInfo.componentStack);
+    // Log for debugging
+    logError('Error caught by AppErrorBoundary', error, { componentStack: errorInfo.componentStack });
   }
 
   handleReset = () => {


### PR DESCRIPTION
## Summary

Migrates remaining `console.warn`, `console.log`, and `console.error` calls to use the centralized logger utilities (`logWarn`, `logInfo`, `logError`) for consistent, redactable error reporting and verbosity control.

Closes #278

## Changes Made

- **src/utils/state.ts**: Replace 6 `console.*` calls with `logWarn`/`logInfo`
- **src/App.tsx**: Replace 3 `console.error` calls with `logError`
- **src/components/AppErrorBoundary.tsx**: Replace 2 `console.error` calls with `logError`
- **src/cli.ts**: Keep `console.error` for user-facing CLI errors (intentional - must always be visible)

## Notes

- User-facing CLI output (`--help`, `--version`, and error messages) intentionally uses `console.*` directly to ensure visibility regardless of debug/test mode
- All tests pass