### PR TITLE
Add Issue button to worktree cards with AI-extracted issue numbers

### DIFF
--- a/src/components/WorktreeCard.tsx
+++ b/src/components/WorktreeCard.tsx
@@ -160,6 +160,7 @@ export interface WorktreeCardProps {
   activeRootPath: string;
   onCopyTree?: () => void;
   onOpenEditor?: () => void;
+  onOpenIssue?: () => void;
   serverState?: DevServerState;
   hasDevScript?: boolean;
   onToggleServer?: () => void;
@@ -296,6 +297,7 @@ const WorktreeCardInner: React.FC<WorktreeCardProps> = ({
   activeRootPath,
   onCopyTree,
   onOpenEditor,
+  onOpenIssue,
   serverState,
   hasDevScript,
   onToggleServer,
@@ -312,15 +314,16 @@ const WorktreeCardInner: React.FC<WorktreeCardProps> = ({
   const headerColor = mood === 'active' ? palette.git.modified : palette.text.primary;
 
   // Calculate widths for the top border
-  // Format: ╭─────────────────────────────────────────[ Copy ]─[ Code ]─╮
+  // Format: ╭─────────────────────────────────────────[ Copy ]─[ Code ]─[ Issue ]─╮
   // Each button: ─[ Label ] = 1 + 1 + label.length + 2 + 1 = label.length + 5
   // Plus trailing ─ before ╮ = 1
   const copyButtonWidth = 4 + 5; // "Copy" = 4 chars + surrounding
   const codeButtonWidth = 4 + 5; // "Code" = 4 chars + surrounding
+  const issueButtonWidth = worktree.issueNumber ? (5 + 5) : 0; // "Issue" = 5 chars + surrounding (only if issue detected)
   const trailingWidth = 1; // trailing ─ before ╮
   // Corner chars: 2 (╭ and ╮)
-  // Total button area: copyButtonWidth + codeButtonWidth + trailingWidth
-  const buttonsWidth = copyButtonWidth + codeButtonWidth + trailingWidth;
+  // Total button area: copyButtonWidth + codeButtonWidth + issueButtonWidth + trailingWidth
+  const buttonsWidth = copyButtonWidth + codeButtonWidth + issueButtonWidth + trailingWidth;
   const cornersWidth = 2;
   const lineWidth = Math.max(0, terminalWidth - buttonsWidth - cornersWidth);
   // Content width: terminal width minus borders (2) and padding (2)
@@ -568,6 +571,16 @@ const WorktreeCardInner: React.FC<WorktreeCardProps> = ({
           onPress={onOpenEditor}
           registerRegion={registerClickRegion}
         />
+        {worktree.issueNumber && (
+          <BorderActionButton
+            id={`${worktree.id}-issue`}
+            label="Issue"
+            color={palette.accent.primary}
+            borderColor={borderColor}
+            onPress={onOpenIssue}
+            registerRegion={registerClickRegion}
+          />
+        )}
         <Text color={borderColor}>{BORDER.horizontal}{BORDER.topRight}</Text>
       </Box>
 
@@ -711,6 +724,7 @@ export const WorktreeCard = React.memo(WorktreeCardInner, (prevProps, nextProps)
   if (prevWt.modifiedCount !== nextWt.modifiedCount) return false;
   if (prevWt.lastActivityTimestamp !== nextWt.lastActivityTimestamp) return false;
   if (prevWt.aiStatus !== nextWt.aiStatus) return false;
+  if (prevWt.issueNumber !== nextWt.issueNumber) return false;
 
   // Compare changes (check count and latest mtime for quick equality)
   const prevChanges = prevProps.changes;

--- a/src/components/WorktreeOverview.tsx
+++ b/src/components/WorktreeOverview.tsx
@@ -23,6 +23,7 @@ export interface WorktreeOverviewProps {
   visibleEnd?: number;
   onCopyTree: (id: string, profile?: string) => void;
   onOpenEditor: (id: string) => void;
+  onOpenIssue: (id: string) => void;
   /** Dev server configuration */
   devServerConfig?: DevServerConfig;
   /** Handler for mouse wheel scrolling */
@@ -109,6 +110,7 @@ export const WorktreeOverview: React.FC<WorktreeOverviewProps> = ({
   visibleEnd,
   onCopyTree,
   onOpenEditor,
+  onOpenIssue,
   devServerConfig,
   onScroll,
   terminalWidth,
@@ -295,6 +297,7 @@ export const WorktreeOverview: React.FC<WorktreeOverviewProps> = ({
             activeRootPath={activeRootPath}
             onCopyTree={() => onCopyTree(worktree.id)}
             onOpenEditor={() => onOpenEditor(worktree.id)}
+            onOpenIssue={worktree.issueNumber ? () => onOpenIssue(worktree.id) : undefined}
             serverState={serverState}
             hasDevScript={hasDevScript}
             onToggleServer={() => handleToggleServer(worktree.id, worktree.path)}

--- a/src/hooks/useWorktreeMonitor.ts
+++ b/src/hooks/useWorktreeMonitor.ts
@@ -88,5 +88,6 @@ export function worktreeStatesToArray(states: Map<string, WorktreeState>): Workt
     aiStatus: state.aiStatus,
     aiNote: state.aiNote,
     aiNoteTimestamp: state.aiNoteTimestamp,
+    issueNumber: state.issueNumber,
   }));
 }

--- a/src/services/ai/index.ts
+++ b/src/services/ai/index.ts
@@ -2,3 +2,4 @@ export * from './client.js';
 export * from './cache.js';
 export * from './identity.js';
 export * from './utils.js';
+export * from './issueExtractor.js';

--- a/src/services/ai/issueExtractor.ts
+++ b/src/services/ai/issueExtractor.ts
@@ -1,0 +1,204 @@
+import { getAIClient } from './client.js';
+import { extractOutputText } from './utils.js';
+import { logDebug } from '../../utils/logger.js';
+
+// Regex patterns to try before using AI (fast, no API cost)
+const ISSUE_PATTERNS = [
+  /issue-(\d+)/i,           // feature/issue-158-description
+  /issues?\/(\d+)/i,        // fix/issues/42
+  /#(\d+)/,                 // feature/#42-description
+  /gh-(\d+)/i,              // fix/GH-42-login-bug or gh-123
+  /jira-(\d+)/i,            // feature/jira-456-task
+];
+
+// In-memory cache: branch name -> issue number (or null if no issue found)
+const issueCache = new Map<string, number | null>();
+
+// Branches that should never have issue numbers
+const SKIP_BRANCHES = ['main', 'master', 'develop', 'staging', 'production', 'release', 'hotfix'];
+
+/**
+ * Extract issue number from a branch name.
+ * Tries regex patterns first (fast, no API cost), falls back to AI for unusual formats.
+ * Results are cached in memory since branch names don't change during a session.
+ *
+ * @param branchName - Git branch name to extract issue number from
+ * @returns Issue number if found, null otherwise
+ */
+export async function extractIssueNumber(branchName: string): Promise<number | null> {
+  // Handle empty or invalid input
+  if (!branchName || typeof branchName !== 'string') {
+    return null;
+  }
+
+  const trimmedBranch = branchName.trim();
+  if (!trimmedBranch) {
+    return null;
+  }
+
+  // Check cache first
+  if (issueCache.has(trimmedBranch)) {
+    return issueCache.get(trimmedBranch)!;
+  }
+
+  // Skip obvious non-issue branches
+  const lowerBranch = trimmedBranch.toLowerCase();
+  if (SKIP_BRANCHES.some(skip => lowerBranch === skip || lowerBranch.startsWith(`${skip}/`))) {
+    issueCache.set(trimmedBranch, null);
+    return null;
+  }
+
+  // Try regex patterns first (fast, no API cost)
+  for (const pattern of ISSUE_PATTERNS) {
+    const match = trimmedBranch.match(pattern);
+    if (match?.[1]) {
+      const num = parseInt(match[1], 10);
+      if (!isNaN(num) && num > 0) {
+        issueCache.set(trimmedBranch, num);
+        return num;
+      }
+    }
+  }
+
+  // AI fallback for unusual patterns
+  const result = await extractIssueNumberWithAI(trimmedBranch);
+  issueCache.set(trimmedBranch, result);
+  return result;
+}
+
+/**
+ * Use AI to extract issue number from unusual branch name formats.
+ * This is called only when regex patterns fail to match.
+ */
+async function extractIssueNumberWithAI(branchName: string): Promise<number | null> {
+  const client = getAIClient();
+  if (!client) {
+    return null;
+  }
+
+  try {
+    const response = await client.responses.create({
+      model: 'gpt-5-nano',
+      instructions: `Extract the GitHub issue number from this git branch name.
+Return JSON: {"issueNumber": <number or null>}
+
+Rules:
+- Look for numbers that represent issue references (like "issue-123", "#42", "GH-15")
+- If multiple numbers exist, prefer the one that looks like an issue reference
+- Return null if no issue number is found or the branch doesn't reference an issue
+- Common non-issue branches: main, develop, feature/general-refactor
+
+Examples:
+"feature/issue-158-add-button" -> {"issueNumber": 158}
+"fix/GH-42-login-bug" -> {"issueNumber": 42}
+"feature/add-dark-mode" -> {"issueNumber": null}
+"refactor/cleanup-v2" -> {"issueNumber": null}`,
+      input: branchName,
+      text: {
+        format: {
+          type: 'json_schema',
+          name: 'issue_extraction',
+          strict: true,
+          schema: {
+            type: 'object',
+            properties: {
+              issueNumber: {
+                oneOf: [
+                  { type: 'number' },
+                  { type: 'null' }
+                ],
+                description: 'The extracted issue number, or null if none found'
+              }
+            },
+            required: ['issueNumber'],
+            additionalProperties: false
+          }
+        }
+      },
+      reasoning: { effort: 'minimal' },
+      max_output_tokens: 64
+    } as any);
+
+    const text = extractOutputText(response);
+    if (!text) {
+      return null;
+    }
+
+    // Parse the JSON response
+    try {
+      const parsed = JSON.parse(text);
+      if (typeof parsed.issueNumber === 'number' && parsed.issueNumber > 0) {
+        return parsed.issueNumber;
+      }
+    } catch {
+      // Try regex extraction as last resort
+      const match = text.match(/"issueNumber"\s*:\s*(\d+)/);
+      if (match?.[1]) {
+        const num = parseInt(match[1], 10);
+        if (!isNaN(num) && num > 0) {
+          return num;
+        }
+      }
+    }
+
+    return null;
+  } catch (error) {
+    // Log error for debugging but don't fail the feature
+    logDebug('AI issue extraction failed', { branch: branchName, error: (error as Error).message });
+    return null;
+  }
+}
+
+/**
+ * Synchronously extract issue number using only regex patterns.
+ * Use this when you need immediate results without waiting for AI.
+ *
+ * @param branchName - Git branch name to extract issue number from
+ * @returns Issue number if found via regex, null otherwise
+ */
+export function extractIssueNumberSync(branchName: string): number | null {
+  if (!branchName || typeof branchName !== 'string') {
+    return null;
+  }
+
+  const trimmedBranch = branchName.trim();
+  if (!trimmedBranch) {
+    return null;
+  }
+
+  // Check cache first
+  if (issueCache.has(trimmedBranch)) {
+    return issueCache.get(trimmedBranch)!;
+  }
+
+  // Skip obvious non-issue branches and cache the result
+  const lowerBranch = trimmedBranch.toLowerCase();
+  if (SKIP_BRANCHES.some(skip => lowerBranch === skip || lowerBranch.startsWith(`${skip}/`))) {
+    issueCache.set(trimmedBranch, null);
+    return null;
+  }
+
+  // Try regex patterns only
+  for (const pattern of ISSUE_PATTERNS) {
+    const match = trimmedBranch.match(pattern);
+    if (match?.[1]) {
+      const num = parseInt(match[1], 10);
+      if (!isNaN(num) && num > 0) {
+        // Cache successful regex match
+        issueCache.set(trimmedBranch, num);
+        return num;
+      }
+    }
+  }
+
+  // Don't cache null here - let async path try AI fallback
+  return null;
+}
+
+/**
+ * Clear the issue number cache.
+ * Useful for testing or when branch names might have changed.
+ */
+export function clearIssueCache(): void {
+  issueCache.clear();
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -113,6 +113,9 @@ export interface Worktree {
 
   /** Timestamp when the note file was last modified (milliseconds since epoch) */
   aiNoteTimestamp?: number;
+
+  /** GitHub issue number extracted from branch name (e.g., 158 from feature/issue-158-description) */
+  issueNumber?: number;
 }
 
 export interface OpenerConfig {

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -138,3 +138,33 @@ export async function openGitHubUrl(cwd: string, page?: 'issues' | 'pulls'): Pro
 export async function openGitHubRepo(cwd: string): Promise<void> {
   return openGitHubUrl(cwd);
 }
+
+/**
+ * Gets the GitHub issue URL for a specific issue number.
+ * @param cwd - Working directory (to get repo info)
+ * @param issueNumber - Issue number to get URL for
+ * @returns The full GitHub issue URL
+ */
+export async function getIssueUrl(cwd: string, issueNumber: number): Promise<string> {
+  const { stdout } = await execa('gh', ['repo', 'view', '--json', 'url', '-q', '.url'], { cwd });
+  const repoUrl = stdout.trim();
+  return `${repoUrl}/issues/${issueNumber}`;
+}
+
+/**
+ * Opens a specific GitHub issue in the default browser.
+ * @param cwd - Working directory (to get repo info)
+ * @param issueNumber - Issue number to open
+ */
+export async function openGitHubIssue(cwd: string, issueNumber: number): Promise<void> {
+  try {
+    const issueUrl = await getIssueUrl(cwd, issueNumber);
+    const { default: open } = await import('open');
+    await open(issueUrl);
+  } catch (error: any) {
+    if (error.code === 'ENOENT') {
+      throw new Error('GitHub CLI (gh) not found. Please install it.');
+    }
+    throw new Error(error.message || 'Failed to open GitHub issue.');
+  }
+}

--- a/tests/services/issueExtractor.test.ts
+++ b/tests/services/issueExtractor.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { extractIssueNumber, extractIssueNumberSync, clearIssueCache } from '../../src/services/ai/issueExtractor.js';
+import * as clientModule from '../../src/services/ai/client.js';
+
+// Mock dependencies
+vi.mock('../../src/services/ai/client.js', () => ({
+  getAIClient: vi.fn()
+}));
+
+describe('Issue Extractor Service', () => {
+  let mockCreate: any;
+
+  beforeEach(() => {
+    clearIssueCache();
+    mockCreate = vi.fn();
+    vi.mocked(clientModule.getAIClient).mockReturnValue({
+      responses: {
+        create: mockCreate
+      }
+    } as any);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('extractIssueNumberSync', () => {
+    it('should extract issue number from feature/issue-158-description pattern', () => {
+      expect(extractIssueNumberSync('feature/issue-158-terminal-busy-feedback')).toBe(158);
+    });
+
+    it('should extract issue number from fix/issue-42-login-bug pattern', () => {
+      expect(extractIssueNumberSync('fix/issue-42-login-bug')).toBe(42);
+    });
+
+    it('should extract issue number from bugfix/issue-100-fix pattern', () => {
+      expect(extractIssueNumberSync('bugfix/issue-100-fix-something')).toBe(100);
+    });
+
+    it('should extract issue number from feature/issues/123 pattern', () => {
+      expect(extractIssueNumberSync('feature/issues/123')).toBe(123);
+    });
+
+    it('should extract issue number from branch/#456-description pattern', () => {
+      expect(extractIssueNumberSync('feature/#456-add-feature')).toBe(456);
+    });
+
+    it('should extract issue number from GH-42 pattern', () => {
+      expect(extractIssueNumberSync('fix/GH-42-login-bug')).toBe(42);
+    });
+
+    it('should extract issue number from gh-123 pattern (lowercase)', () => {
+      expect(extractIssueNumberSync('feature/gh-123-add-feature')).toBe(123);
+    });
+
+    it('should extract issue number from jira-456 pattern', () => {
+      expect(extractIssueNumberSync('feature/jira-456-task')).toBe(456);
+    });
+
+    it('should be case insensitive for issue keyword', () => {
+      expect(extractIssueNumberSync('feature/ISSUE-200-uppercase')).toBe(200);
+      expect(extractIssueNumberSync('feature/Issue-201-mixed')).toBe(201);
+    });
+
+    it('should return null for main branch', () => {
+      expect(extractIssueNumberSync('main')).toBeNull();
+    });
+
+    it('should return null for master branch', () => {
+      expect(extractIssueNumberSync('master')).toBeNull();
+    });
+
+    it('should return null for develop branch', () => {
+      expect(extractIssueNumberSync('develop')).toBeNull();
+    });
+
+    it('should return null for staging branch', () => {
+      expect(extractIssueNumberSync('staging')).toBeNull();
+    });
+
+    it('should return null for release/ prefixed branches', () => {
+      expect(extractIssueNumberSync('release/v1.0.0')).toBeNull();
+    });
+
+    it('should return null for branches without issue pattern', () => {
+      expect(extractIssueNumberSync('feature/add-dark-mode')).toBeNull();
+    });
+
+    it('should return null for empty string', () => {
+      expect(extractIssueNumberSync('')).toBeNull();
+    });
+
+    it('should return null for null input', () => {
+      expect(extractIssueNumberSync(null as any)).toBeNull();
+    });
+
+    it('should return null for undefined input', () => {
+      expect(extractIssueNumberSync(undefined as any)).toBeNull();
+    });
+
+    it('should handle whitespace-only input', () => {
+      expect(extractIssueNumberSync('   ')).toBeNull();
+    });
+
+    it('should handle branches with trailing/leading whitespace', () => {
+      expect(extractIssueNumberSync('  feature/issue-99-test  ')).toBe(99);
+    });
+  });
+
+  describe('extractIssueNumber (async with AI fallback)', () => {
+    it('should use regex first and not call AI for standard patterns', async () => {
+      const result = await extractIssueNumber('feature/issue-158-description');
+
+      expect(result).toBe(158);
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it('should cache results to avoid redundant calls', async () => {
+      const result1 = await extractIssueNumber('feature/issue-300-test');
+      const result2 = await extractIssueNumber('feature/issue-300-test');
+
+      expect(result1).toBe(300);
+      expect(result2).toBe(300);
+      // Both should come from cache, AI never called
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it('should use regex for GH- pattern and not call AI', async () => {
+      const result = await extractIssueNumber('feature/GH-789-bug-fix');
+
+      expect(result).toBe(789);
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to AI for unusual branch patterns when AI is available', async () => {
+      mockCreate.mockResolvedValue({
+        output_text: JSON.stringify({ issueNumber: 999 })
+      });
+
+      const result = await extractIssueNumber('feature/ticket-999-unusual-pattern');
+
+      expect(result).toBe(999);
+      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({
+        model: 'gpt-5-nano'
+      }));
+    });
+
+    it('should return null when AI is unavailable for unusual patterns', async () => {
+      vi.mocked(clientModule.getAIClient).mockReturnValue(null);
+
+      const result = await extractIssueNumber('feature/ticket-789-unusual-pattern');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when AI returns null', async () => {
+      mockCreate.mockResolvedValue({
+        output_text: JSON.stringify({ issueNumber: null })
+      });
+
+      const result = await extractIssueNumber('feature/no-issue-here');
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle AI API errors gracefully', async () => {
+      mockCreate.mockRejectedValue(new Error('API error'));
+
+      const result = await extractIssueNumber('feature/ticket-789-api-error');
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle malformed AI response gracefully', async () => {
+      mockCreate.mockResolvedValue({
+        output_text: 'not valid json'
+      });
+
+      const result = await extractIssueNumber('feature/ticket-789-bad-json');
+
+      expect(result).toBeNull();
+    });
+
+    it('should extract from AI response with regex fallback for malformed JSON', async () => {
+      mockCreate.mockResolvedValue({
+        output_text: '{"issueNumber": 555, extra: invalid}'
+      });
+
+      const result = await extractIssueNumber('feature/unusual-pattern-here');
+
+      // Should use regex fallback to extract 555 from the malformed JSON
+      expect(result).toBe(555);
+    });
+
+    it('should skip AI for standard skip branches', async () => {
+      const branches = ['main', 'master', 'develop', 'staging', 'production'];
+
+      for (const branch of branches) {
+        clearIssueCache(); // Clear cache between tests
+        const result = await extractIssueNumber(branch);
+        expect(result).toBeNull();
+        expect(mockCreate).not.toHaveBeenCalled();
+      }
+    });
+  });
+
+  describe('clearIssueCache', () => {
+    it('should clear the cache and allow re-extraction', async () => {
+      // First extraction
+      const result1 = await extractIssueNumber('feature/issue-500-test');
+      expect(result1).toBe(500);
+
+      // Clear cache
+      clearIssueCache();
+
+      // Second extraction should still work (cache miss, then cache hit)
+      const result2 = await extractIssueNumber('feature/issue-500-test');
+      expect(result2).toBe(500);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds an "Issue" button to worktree cards that links directly to the GitHub issue referenced in the branch name. The feature intelligently extracts issue numbers using a combination of regex patterns and AI fallback.

Closes #276

## Changes Made
- Add `issueNumber` field to Worktree type for tracking GitHub issue references
- Create `issueExtractor` service with regex patterns (`issue-`, `GH-`, `jira-`, `#`) and AI fallback using GPT-5-nano
- Add `getIssueUrl()` and `openGitHubIssue()` helpers to github.ts
- Integrate issue extraction into WorktreeMonitor on initialization (sync regex + async AI fallback)
- Add conditional "Issue" button to WorktreeCard top border (only shown when issue detected)
- Wire `onOpenIssue` handler through WorktreeOverview to App
- Add 31 unit tests for issue extraction service

## Implementation Details
- **Zero-cost for common patterns**: Regex patterns match instantly without API calls
- **AI fallback**: Unusual branch naming conventions fall back to GPT-5-nano for extraction
- **Caching**: Results are cached in memory to avoid redundant work
- **Non-blocking**: Issue extraction runs asynchronously and updates the UI when complete