### PR TITLE
fix(click-regions): force re-registration on scroll and resize

### DIFF
--- a/src/components/WorktreeOverview.tsx
+++ b/src/components/WorktreeOverview.tsx
@@ -220,6 +220,9 @@ export const WorktreeOverview: React.FC<WorktreeOverviewProps> = ({
     bounds?: { x: number; y: number; width: number; height: number },
     handler?: () => void
   ) => {
+    if (process.env.CANOPY_DEBUG_CLICK) {
+      console.error(`[CLICK] ${bounds ? 'Register' : 'Deregister'}: ${id}`, bounds ?? '');
+    }
     if (!bounds || !handler) {
       clickRegionsRef.current.delete(id);
       return;
@@ -245,9 +248,19 @@ export const WorktreeOverview: React.FC<WorktreeOverviewProps> = ({
         return;
       }
 
-      for (const { bounds, handler } of clickRegionsRef.current.values()) {
+      if (process.env.CANOPY_DEBUG_CLICK) {
+        console.error(`[CLICK] Mouse event at (${event.x}, ${event.y})`);
+        console.error(`[CLICK] Registered regions:`, [...clickRegionsRef.current.keys()]);
+      }
+
+      for (const [id, { bounds, handler }] of clickRegionsRef.current.entries()) {
         const withinX = event.x >= bounds.x && event.x < bounds.x + bounds.width;
         const withinY = event.y >= bounds.y && event.y < bounds.y + bounds.height;
+
+        if (process.env.CANOPY_DEBUG_CLICK) {
+          console.error(`[CLICK] Testing ${id}: bounds=${JSON.stringify(bounds)}, hit=${withinX && withinY}`);
+        }
+
         if (withinX && withinY) {
           handler();
           break;
@@ -272,7 +285,7 @@ export const WorktreeOverview: React.FC<WorktreeOverviewProps> = ({
           </Text>
         </Box>
       )}
-      {sliced.map((worktree) => {
+      {sliced.map((worktree, index) => {
         const changes = worktreeChanges.get(worktree.id) ?? {
           ...FALLBACK_CHANGES,
           worktreeId: worktree.id,
@@ -309,6 +322,7 @@ export const WorktreeOverview: React.FC<WorktreeOverviewProps> = ({
             isMainWorktree={isMainWorktree}
             registerClickRegion={registerClickRegion}
             terminalWidth={terminalWidth}
+            listIndex={index}
           />
         );
       })}

--- a/src/components/WorktreeOverview.tsx
+++ b/src/components/WorktreeOverview.tsx
@@ -24,6 +24,7 @@ export interface WorktreeOverviewProps {
   onCopyTree: (id: string, profile?: string) => void;
   onOpenEditor: (id: string) => void;
   onOpenIssue: (id: string) => void;
+  onOpenPR: (id: string) => void;
   /** Dev server configuration */
   devServerConfig?: DevServerConfig;
   /** Handler for mouse wheel scrolling */
@@ -111,6 +112,7 @@ export const WorktreeOverview: React.FC<WorktreeOverviewProps> = ({
   onCopyTree,
   onOpenEditor,
   onOpenIssue,
+  onOpenPR,
   devServerConfig,
   onScroll,
   terminalWidth,
@@ -298,6 +300,7 @@ export const WorktreeOverview: React.FC<WorktreeOverviewProps> = ({
             onCopyTree={() => onCopyTree(worktree.id)}
             onOpenEditor={() => onOpenEditor(worktree.id)}
             onOpenIssue={worktree.issueNumber ? () => onOpenIssue(worktree.id) : undefined}
+            onOpenPR={worktree.prUrl ? () => onOpenPR(worktree.id) : undefined}
             serverState={serverState}
             hasDevScript={hasDevScript}
             onToggleServer={() => handleToggleServer(worktree.id, worktree.path)}

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -75,6 +75,20 @@ export type CanopyEventMap = {
   // Dev Server Events
   'server:update': DevServerState;
   'server:error': { worktreeId: string; error: string };
+
+  // Pull Request Events
+  'sys:pr:detected': {
+    worktreeId: string;
+    prNumber: number;
+    prUrl: string;
+    prState: 'open' | 'merged' | 'closed';
+    /** The issue number this PR was detected for */
+    issueNumber: number;
+  };
+  /** Emitted when PR data should be cleared (branch/issue changed or worktree removed) */
+  'sys:pr:cleared': {
+    worktreeId: string;
+  };
 };
 
 // 3. Create Bus

--- a/src/services/monitor/PullRequestService.ts
+++ b/src/services/monitor/PullRequestService.ts
@@ -1,0 +1,430 @@
+import { events } from '../events.js';
+import { batchCheckLinkedPRs, type PRCheckCandidate, type LinkedPR } from '../../utils/github.js';
+import { logInfo, logWarn, logDebug } from '../../utils/logger.js';
+import type { WorktreeState } from './WorktreeMonitor.js';
+
+// Default polling interval: 60 seconds (safe for rate limits - uses ~1.2% of hourly budget)
+const DEFAULT_POLL_INTERVAL_MS = 60 * 1000;
+
+// Backoff intervals for error handling
+const ERROR_BACKOFF_INTERVALS = [
+  5 * 60 * 1000,   // 5 minutes after first error
+  10 * 60 * 1000,  // 10 minutes after second error
+  30 * 60 * 1000,  // 30 minutes after third+ error
+];
+
+// Maximum consecutive errors before disabling polling
+const MAX_CONSECUTIVE_ERRORS = 3;
+
+// Debounce delay for batching worktree updates
+const UPDATE_DEBOUNCE_MS = 100;
+
+/**
+ * Tracked context for a worktree - used to detect when branch/issue changes.
+ */
+interface WorktreeContext {
+  issueNumber?: number;
+  branchName?: string;
+}
+
+/**
+ * PR detection result for a single worktree.
+ */
+export interface PRDetectionResult {
+  worktreeId: string;
+  prNumber: number;
+  prUrl: string;
+  prState: 'open' | 'merged' | 'closed';
+}
+
+/**
+ * PullRequestService manages centralized polling for PR detection across all worktrees.
+ *
+ * Architecture:
+ * - Singleton service that subscribes directly to sys:worktree:update events
+ * - Detects context changes (branch/issue) and emits sys:pr:cleared immediately
+ * - Batches all worktree checks into a single GraphQL query
+ * - Stops checking worktrees once a PR is found (resolved state)
+ * - Emits events when PRs are detected/cleared for UI updates
+ *
+ * Rate Limit Safety:
+ * - Default 60s polling = 60 requests/hour = 1.2% of 5000 point budget
+ * - Single GraphQL query checks all worktrees (batched)
+ * - Exponential backoff on errors
+ */
+class PullRequestService {
+  private pollTimer: NodeJS.Timeout | null = null;
+  private pollIntervalMs: number = DEFAULT_POLL_INTERVAL_MS;
+  private cwd: string = '';
+  private isPolling: boolean = false;
+  private consecutiveErrors: number = 0;
+  private isEnabled: boolean = true;
+
+  // Track worktrees that need PR checking
+  // Key: worktreeId, Value: { issueNumber, branchName }
+  private candidates = new Map<string, WorktreeContext>();
+
+  // Track resolved worktrees (already have a PR detected)
+  // These are excluded from future polling
+  private resolvedWorktrees = new Set<string>();
+
+  // Store detected PRs for quick lookup
+  private detectedPRs = new Map<string, LinkedPR>();
+
+  // Timer for debounced check after worktree updates
+  private updateDebounceTimer: NodeJS.Timeout | null = null;
+
+  // Track if we've done the initial check
+  private initialCheckDone: boolean = false;
+
+  // Event unsubscribe functions
+  private unsubscribers: (() => void)[] = [];
+
+  constructor() {
+    // Subscribe to worktree events directly - this is the source of truth
+    this.unsubscribers.push(
+      events.on('sys:worktree:update', this.handleWorktreeUpdate.bind(this))
+    );
+    this.unsubscribers.push(
+      events.on('sys:worktree:remove', this.handleWorktreeRemove.bind(this))
+    );
+  }
+
+  /**
+   * Handle worktree update events - the core of reactive state management.
+   * Detects context changes and immediately clears/updates PR data.
+   */
+  private handleWorktreeUpdate(state: WorktreeState): void {
+    if (!this.isPolling) {
+      return;
+    }
+
+    const currentContext = this.candidates.get(state.id);
+    const newIssueNumber = state.issueNumber;
+    const newBranchName = state.branch;
+
+    // Detect if the "identity" of the work context changed
+    const contextChanged =
+      currentContext?.issueNumber !== newIssueNumber ||
+      currentContext?.branchName !== newBranchName;
+
+    if (contextChanged && currentContext) {
+      // Context changed - CLEAR immediately
+      logInfo('Worktree context changed - clearing PR state', {
+        worktreeId: state.id,
+        oldIssue: currentContext.issueNumber,
+        newIssue: newIssueNumber,
+        oldBranch: currentContext.branchName,
+        newBranch: newBranchName,
+      });
+
+      this.resolvedWorktrees.delete(state.id);
+      this.detectedPRs.delete(state.id);
+
+      // Emit clear event so UI removes the PR button immediately
+      events.emit('sys:pr:cleared', { worktreeId: state.id });
+    }
+
+    // Update or register the candidate
+    if (newIssueNumber) {
+      // Has an issue number - track as candidate
+      this.candidates.set(state.id, {
+        issueNumber: newIssueNumber,
+        branchName: newBranchName,
+      });
+
+      // Schedule a debounced check if context changed or this is a new candidate
+      if (contextChanged || !currentContext) {
+        this.scheduleDebounceCheck();
+      }
+    } else {
+      // No issue number - stop tracking this worktree
+      if (currentContext) {
+        this.candidates.delete(state.id);
+        logDebug('Worktree no longer has issue number - removed from candidates', {
+          worktreeId: state.id,
+        });
+      }
+    }
+  }
+
+  /**
+   * Handle worktree removal events.
+   */
+  private handleWorktreeRemove({ worktreeId }: { worktreeId: string }): void {
+    if (this.candidates.has(worktreeId) || this.detectedPRs.has(worktreeId)) {
+      this.candidates.delete(worktreeId);
+      this.resolvedWorktrees.delete(worktreeId);
+      this.detectedPRs.delete(worktreeId);
+
+      // Emit clear event
+      events.emit('sys:pr:cleared', { worktreeId });
+
+      logDebug('Worktree removed - cleared PR state', { worktreeId });
+    }
+  }
+
+  /**
+   * Schedule a debounced PR check.
+   * This batches rapid updates (e.g., multiple worktrees updating at once).
+   */
+  private scheduleDebounceCheck(): void {
+    if (this.updateDebounceTimer) {
+      clearTimeout(this.updateDebounceTimer);
+    }
+
+    this.updateDebounceTimer = setTimeout(() => {
+      this.updateDebounceTimer = null;
+      this.initialCheckDone = true;
+
+      if (this.hasUnresolvedCandidates()) {
+        logDebug('Running debounced PR check', { candidateCount: this.candidates.size });
+        void this.checkForPRs();
+
+        // Ensure polling continues if it was paused
+        if (!this.pollTimer) {
+          this.scheduleNextPoll();
+        }
+      }
+    }, UPDATE_DEBOUNCE_MS);
+  }
+
+  /**
+   * Initialize the service with the working directory.
+   * @param cwd - Working directory (repo root)
+   */
+  public initialize(cwd: string): void {
+    this.cwd = cwd;
+    logInfo('PullRequestService initialized', { cwd });
+  }
+
+  /**
+   * Start the polling loop.
+   * Note: Candidates are now registered automatically via sys:worktree:update events.
+   * @param intervalMs - Optional custom polling interval
+   */
+  public start(intervalMs?: number): void {
+    if (this.isPolling) {
+      logWarn('PullRequestService already polling');
+      return;
+    }
+
+    if (!this.cwd) {
+      logWarn('PullRequestService not initialized - call initialize() first');
+      return;
+    }
+
+    if (intervalMs) {
+      this.pollIntervalMs = intervalMs;
+    }
+
+    this.isPolling = true;
+    this.isEnabled = true;
+    this.consecutiveErrors = 0;
+    this.initialCheckDone = false;
+
+    logInfo('PullRequestService started', { intervalMs: this.pollIntervalMs });
+
+    // Start polling loop - initial check will happen when worktree updates arrive
+    this.scheduleNextPoll();
+  }
+
+  /**
+   * Stop the polling loop.
+   */
+  public stop(): void {
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+    }
+    if (this.updateDebounceTimer) {
+      clearTimeout(this.updateDebounceTimer);
+      this.updateDebounceTimer = null;
+    }
+    this.isPolling = false;
+    logInfo('PullRequestService stopped');
+  }
+
+  /**
+   * Force an immediate PR check (e.g., on manual refresh).
+   */
+  public async refresh(): Promise<void> {
+    if (!this.cwd) {
+      return;
+    }
+    // Re-enable if disabled due to errors
+    this.isEnabled = true;
+    this.consecutiveErrors = 0;
+    await this.checkForPRs();
+
+    // Resume polling if it was paused
+    if (this.isPolling && !this.pollTimer && this.hasUnresolvedCandidates()) {
+      this.scheduleNextPoll();
+    }
+  }
+
+  /**
+   * Clear all state and stop polling.
+   */
+  public reset(): void {
+    this.stop();
+    this.candidates.clear();
+    this.resolvedWorktrees.clear();
+    this.detectedPRs.clear();
+    this.consecutiveErrors = 0;
+    this.isEnabled = true;
+    this.initialCheckDone = false;
+  }
+
+  /**
+   * Clean up event subscriptions.
+   */
+  public destroy(): void {
+    this.reset();
+    for (const unsubscribe of this.unsubscribers) {
+      unsubscribe();
+    }
+    this.unsubscribers = [];
+  }
+
+  /**
+   * Schedule the next poll with appropriate interval.
+   */
+  private scheduleNextPoll(): void {
+    if (!this.isPolling || !this.isEnabled) {
+      return;
+    }
+
+    // Don't schedule if there's nothing to check
+    if (!this.hasUnresolvedCandidates()) {
+      logDebug('All candidates resolved - pausing polling until new candidates appear');
+      return;
+    }
+
+    // Calculate backoff if we have errors
+    let interval = this.pollIntervalMs;
+    if (this.consecutiveErrors > 0) {
+      const backoffIndex = Math.min(this.consecutiveErrors - 1, ERROR_BACKOFF_INTERVALS.length - 1);
+      interval = ERROR_BACKOFF_INTERVALS[backoffIndex];
+      logDebug('Using backoff interval', { errors: this.consecutiveErrors, intervalMs: interval });
+    }
+
+    this.pollTimer = setTimeout(() => {
+      this.pollTimer = null;
+      void this.checkForPRs().then(() => this.scheduleNextPoll());
+    }, interval);
+  }
+
+  /**
+   * Check if there are any unresolved candidates that need checking.
+   */
+  private hasUnresolvedCandidates(): boolean {
+    for (const worktreeId of this.candidates.keys()) {
+      if (!this.resolvedWorktrees.has(worktreeId)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Execute a PR check for all registered candidates.
+   */
+  private async checkForPRs(): Promise<void> {
+    // Get candidates that haven't been resolved yet
+    const activeCandidates: PRCheckCandidate[] = [];
+    for (const [worktreeId, context] of this.candidates) {
+      if (!this.resolvedWorktrees.has(worktreeId)) {
+        activeCandidates.push({
+          worktreeId,
+          issueNumber: context.issueNumber,
+          branchName: context.branchName,
+        });
+      }
+    }
+
+    if (activeCandidates.length === 0) {
+      logDebug('No candidates to check for PRs - all resolved or none registered');
+      return;
+    }
+
+    logDebug('Checking PRs for candidates', { count: activeCandidates.length });
+
+    try {
+      const result = await batchCheckLinkedPRs(this.cwd, activeCandidates);
+
+      if (result.error) {
+        this.handleError(result.error);
+        return;
+      }
+
+      // Reset error count on success
+      this.consecutiveErrors = 0;
+
+      // Process results
+      for (const [worktreeId, checkResult] of result.results) {
+        if (checkResult.pr) {
+          // PR found! Mark as resolved and emit event
+          this.resolvedWorktrees.add(worktreeId);
+          this.detectedPRs.set(worktreeId, checkResult.pr);
+
+          logInfo('PR detected for worktree', {
+            worktreeId,
+            prNumber: checkResult.pr.number,
+            prState: checkResult.pr.state,
+          });
+
+          // Emit event for UI update
+          events.emit('sys:pr:detected', {
+            worktreeId,
+            prNumber: checkResult.pr.number,
+            prUrl: checkResult.pr.url,
+            prState: checkResult.pr.state,
+            issueNumber: checkResult.issueNumber!,
+          });
+        }
+      }
+    } catch (error) {
+      this.handleError(error instanceof Error ? error.message : 'Unknown error');
+    }
+  }
+
+  /**
+   * Handle errors with backoff logic.
+   */
+  private handleError(errorMsg: string): void {
+    this.consecutiveErrors++;
+    logWarn('PR check failed', { error: errorMsg, consecutiveErrors: this.consecutiveErrors });
+
+    if (this.consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+      logWarn('Too many consecutive errors - disabling PR polling until manual refresh');
+      this.isEnabled = false;
+      events.emit('ui:notify', {
+        type: 'warning',
+        message: 'PR detection paused due to errors. Press R to retry.',
+      });
+    }
+  }
+
+  /**
+   * Get current service status for debugging.
+   */
+  public getStatus(): {
+    isPolling: boolean;
+    isEnabled: boolean;
+    candidateCount: number;
+    resolvedCount: number;
+    consecutiveErrors: number;
+  } {
+    return {
+      isPolling: this.isPolling,
+      isEnabled: this.isEnabled,
+      candidateCount: this.candidates.size,
+      resolvedCount: this.resolvedWorktrees.size,
+      consecutiveErrors: this.consecutiveErrors,
+    };
+  }
+}
+
+// Export singleton instance
+export const pullRequestService = new PullRequestService();

--- a/src/services/monitor/index.ts
+++ b/src/services/monitor/index.ts
@@ -1,2 +1,3 @@
 export { WorktreeMonitor, type WorktreeState } from './WorktreeMonitor.js';
 export { worktreeService } from './WorktreeService.js';
+export { pullRequestService, type PRDetectionResult } from './PullRequestService.js';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -116,6 +116,15 @@ export interface Worktree {
 
   /** GitHub issue number extracted from branch name (e.g., 158 from feature/issue-158-description) */
   issueNumber?: number;
+
+  /** GitHub pull request number linked to this worktree's issue or branch */
+  prNumber?: number;
+
+  /** GitHub pull request URL for quick access */
+  prUrl?: string;
+
+  /** Pull request state: open, merged, or closed */
+  prState?: 'open' | 'merged' | 'closed';
 }
 
 export interface OpenerConfig {

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -168,3 +168,284 @@ export async function openGitHubIssue(cwd: string, issueNumber: number): Promise
     throw new Error(error.message || 'Failed to open GitHub issue.');
   }
 }
+
+/**
+ * Opens a specific GitHub pull request in the default browser.
+ * @param prUrl - Full URL of the pull request
+ */
+export async function openGitHubPR(prUrl: string): Promise<void> {
+  try {
+    const { default: open } = await import('open');
+    await open(prUrl);
+  } catch (error: any) {
+    throw new Error(error.message || 'Failed to open GitHub pull request.');
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PR Detection via GraphQL
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Represents a detected pull request linked to an issue or branch.
+ */
+export interface LinkedPR {
+  number: number;
+  url: string;
+  state: 'open' | 'merged' | 'closed';
+  isDraft: boolean;
+}
+
+/**
+ * Result of checking for linked PRs for a single issue/branch.
+ */
+export interface PRCheckResult {
+  issueNumber?: number;
+  branchName?: string;
+  pr: LinkedPR | null;
+}
+
+/**
+ * Result of batch PR detection.
+ */
+export interface BatchPRCheckResult {
+  results: Map<string, PRCheckResult>; // keyed by worktree ID
+  error?: string;
+}
+
+/**
+ * Input for batch PR check - worktree candidates.
+ */
+export interface PRCheckCandidate {
+  worktreeId: string;
+  issueNumber?: number;
+  branchName?: string;
+}
+
+/**
+ * Get repository owner and name from a working directory.
+ * Caches result to avoid repeated CLI calls.
+ */
+let repoInfoCache: { cwd: string; owner: string; repo: string } | null = null;
+
+export async function getRepoInfo(cwd: string): Promise<{ owner: string; repo: string } | null> {
+  // Return cached result if same cwd
+  if (repoInfoCache && repoInfoCache.cwd === cwd) {
+    return { owner: repoInfoCache.owner, repo: repoInfoCache.repo };
+  }
+
+  try {
+    const { stdout: repoInfo } = await execa(
+      'gh',
+      ['repo', 'view', '--json', 'owner,name', '-q', '.owner.login + "/" + .name'],
+      { cwd }
+    );
+    const [owner, repo] = repoInfo.trim().split('/');
+
+    if (!owner || !repo) {
+      return null;
+    }
+
+    repoInfoCache = { cwd, owner, repo };
+    return { owner, repo };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a batched GraphQL query to check multiple issues for linked PRs.
+ * Uses aliases to batch multiple issue checks into one API call.
+ *
+ * The query checks:
+ * 1. Issue timeline for CrossReferencedEvent where source is a PullRequest
+ * 2. PRs with matching headRefName (fallback for unlinked PRs)
+ */
+function buildBatchPRQuery(
+  owner: string,
+  repo: string,
+  candidates: PRCheckCandidate[]
+): string {
+  const issueQueries: string[] = [];
+  const branchQueries: string[] = [];
+
+  for (const candidate of candidates) {
+    const alias = `wt_${candidate.worktreeId.replace(/[^a-zA-Z0-9]/g, '_')}`;
+
+    // Query by issue number (check timeline for cross-references)
+    if (candidate.issueNumber) {
+      issueQueries.push(`
+        ${alias}_issue: repository(owner: "${owner}", name: "${repo}") {
+          issue(number: ${candidate.issueNumber}) {
+            timelineItems(itemTypes: [CROSS_REFERENCED_EVENT], last: 10) {
+              nodes {
+                ... on CrossReferencedEvent {
+                  source {
+                    ... on PullRequest {
+                      number
+                      url
+                      state
+                      isDraft
+                      merged
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `);
+    }
+
+    // Also query by branch name (fallback for PRs not linked via "Closes #X")
+    if (candidate.branchName) {
+      branchQueries.push(`
+        ${alias}_branch: repository(owner: "${owner}", name: "${repo}") {
+          pullRequests(first: 1, states: [OPEN, MERGED], headRefName: "${candidate.branchName}") {
+            nodes {
+              number
+              url
+              state
+              isDraft
+              merged
+            }
+          }
+        }
+      `);
+    }
+  }
+
+  return `query { ${issueQueries.join('\n')} ${branchQueries.join('\n')} }`;
+}
+
+/**
+ * Parse GraphQL response to extract PR information per worktree.
+ */
+function parseBatchPRResponse(
+  data: any,
+  candidates: PRCheckCandidate[]
+): Map<string, PRCheckResult> {
+  const results = new Map<string, PRCheckResult>();
+
+  for (const candidate of candidates) {
+    const alias = `wt_${candidate.worktreeId.replace(/[^a-zA-Z0-9]/g, '_')}`;
+    let foundPR: LinkedPR | null = null;
+
+    // Check issue timeline results first (more reliable linkage)
+    const issueData = data?.[`${alias}_issue`]?.issue?.timelineItems?.nodes;
+    if (issueData && Array.isArray(issueData)) {
+      // Filter for valid PR sources, prefer OPEN > MERGED > CLOSED
+      const prs: LinkedPR[] = [];
+      for (const node of issueData) {
+        const source = node?.source;
+        if (source?.number && source?.url) {
+          prs.push({
+            number: source.number,
+            url: source.url,
+            state: source.merged ? 'merged' : (source.state?.toLowerCase() as 'open' | 'closed') || 'open',
+            isDraft: source.isDraft ?? false,
+          });
+        }
+      }
+
+      // Pick best PR: prefer open, then merged, then closed (most recent within each category)
+      const openPRs = prs.filter(pr => pr.state === 'open');
+      const mergedPRs = prs.filter(pr => pr.state === 'merged');
+      const closedPRs = prs.filter(pr => pr.state === 'closed');
+
+      if (openPRs.length > 0) {
+        foundPR = openPRs[openPRs.length - 1]; // Latest open
+      } else if (mergedPRs.length > 0) {
+        foundPR = mergedPRs[mergedPRs.length - 1]; // Latest merged
+      } else if (closedPRs.length > 0) {
+        foundPR = closedPRs[closedPRs.length - 1]; // Latest closed
+      }
+    }
+
+    // If no PR found via issue, check branch-based lookup
+    if (!foundPR) {
+      const branchData = data?.[`${alias}_branch`]?.pullRequests?.nodes;
+      if (branchData && Array.isArray(branchData) && branchData.length > 0) {
+        const pr = branchData[0];
+        if (pr?.number && pr?.url) {
+          foundPR = {
+            number: pr.number,
+            url: pr.url,
+            state: pr.merged ? 'merged' : (pr.state?.toLowerCase() as 'open' | 'closed') || 'open',
+            isDraft: pr.isDraft ?? false,
+          };
+        }
+      }
+    }
+
+    results.set(candidate.worktreeId, {
+      issueNumber: candidate.issueNumber,
+      branchName: candidate.branchName,
+      pr: foundPR,
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Batch check for PRs linked to multiple worktrees.
+ * Executes a single GraphQL query that checks all candidates.
+ *
+ * @param cwd - Working directory (to determine repo context)
+ * @param candidates - Worktrees to check for linked PRs
+ * @returns Map of worktree ID to PR check result
+ */
+export async function batchCheckLinkedPRs(
+  cwd: string,
+  candidates: PRCheckCandidate[]
+): Promise<BatchPRCheckResult> {
+  if (candidates.length === 0) {
+    return { results: new Map() };
+  }
+
+  try {
+    // Get repo info
+    const repoInfo = await getRepoInfo(cwd);
+    if (!repoInfo) {
+      return { results: new Map(), error: 'not a GitHub repository' };
+    }
+
+    // Build and execute the batched query
+    const query = buildBatchPRQuery(repoInfo.owner, repoInfo.repo, candidates);
+
+    const { stdout } = await execa(
+      'gh',
+      ['api', 'graphql', '-f', `query=${query}`],
+      { cwd }
+    );
+
+    const response = JSON.parse(stdout);
+
+    // Check for GraphQL errors
+    if (response.errors && response.errors.length > 0) {
+      const errorMsg = response.errors[0]?.message || 'GraphQL query failed';
+      return { results: new Map(), error: errorMsg };
+    }
+
+    // Parse results
+    const results = parseBatchPRResponse(response.data, candidates);
+    return { results };
+  } catch (error: any) {
+    // Handle common errors
+    if (error.code === 'ENOENT') {
+      return { results: new Map(), error: 'gh CLI not installed' };
+    }
+
+    const stderr = error.stderr || error.message || '';
+
+    if (stderr.includes('auth') || stderr.includes('login') || stderr.includes('token')) {
+      return { results: new Map(), error: 'gh auth required' };
+    }
+    if (stderr.includes('rate limit')) {
+      return { results: new Map(), error: 'rate limit exceeded' };
+    }
+
+    return { results: new Map(), error: 'GitHub API unavailable' };
+  }
+}

--- a/tests/components/WorktreeOverview.test.tsx
+++ b/tests/components/WorktreeOverview.test.tsx
@@ -157,6 +157,9 @@ describe('WorktreeOverview', () => {
         focusedWorktreeId="alpha"
         onCopyTree={vi.fn()}
         onOpenEditor={vi.fn()}
+        onOpenIssue={vi.fn()}
+        onOpenPR={vi.fn()}
+        terminalWidth={100}
       />
     );
 
@@ -188,6 +191,9 @@ describe('WorktreeOverview', () => {
         visibleEnd={3}
         onCopyTree={vi.fn()}
         onOpenEditor={vi.fn()}
+        onOpenIssue={vi.fn()}
+        onOpenPR={vi.fn()}
+        terminalWidth={100}
       />
     );
 
@@ -216,12 +222,13 @@ describe('WorktreeOverview', () => {
           activeWorktreeId="main"
           activeRootPath="/repo/main"
           focusedWorktreeId="feature"
-          expandedWorktreeIds={new Set()}
           visibleStart={1}
           visibleEnd={3}
-          onToggleExpand={vi.fn()}
           onCopyTree={vi.fn()}
           onOpenEditor={vi.fn()}
+          onOpenIssue={vi.fn()}
+          onOpenPR={vi.fn()}
+          terminalWidth={100}
         />
       );
 
@@ -249,12 +256,13 @@ describe('WorktreeOverview', () => {
           activeWorktreeId="main"
           activeRootPath="/repo/main"
           focusedWorktreeId="main"
-          expandedWorktreeIds={new Set()}
           visibleStart={0}
           visibleEnd={2}
-          onToggleExpand={vi.fn()}
           onCopyTree={vi.fn()}
           onOpenEditor={vi.fn()}
+          onOpenIssue={vi.fn()}
+          onOpenPR={vi.fn()}
+          terminalWidth={100}
         />
       );
 
@@ -281,12 +289,13 @@ describe('WorktreeOverview', () => {
           activeWorktreeId="master"
           activeRootPath="/repo/master"
           focusedWorktreeId="feature"
-          expandedWorktreeIds={new Set()}
           visibleStart={1}
           visibleEnd={3}
-          onToggleExpand={vi.fn()}
           onCopyTree={vi.fn()}
           onOpenEditor={vi.fn()}
+          onOpenIssue={vi.fn()}
+          onOpenPR={vi.fn()}
+          terminalWidth={100}
         />
       );
 
@@ -312,12 +321,13 @@ describe('WorktreeOverview', () => {
           activeWorktreeId="develop"
           activeRootPath="/repo/develop"
           focusedWorktreeId="feature"
-          expandedWorktreeIds={new Set()}
           visibleStart={1}
           visibleEnd={3}
-          onToggleExpand={vi.fn()}
           onCopyTree={vi.fn()}
           onOpenEditor={vi.fn()}
+          onOpenIssue={vi.fn()}
+          onOpenPR={vi.fn()}
+          terminalWidth={100}
         />
       );
 
@@ -341,12 +351,13 @@ describe('WorktreeOverview', () => {
           activeWorktreeId="main"
           activeRootPath="/repo/main"
           focusedWorktreeId="main"
-          expandedWorktreeIds={new Set()}
           visibleStart={0}
           visibleEnd={1}
-          onToggleExpand={vi.fn()}
           onCopyTree={vi.fn()}
           onOpenEditor={vi.fn()}
+          onOpenIssue={vi.fn()}
+          onOpenPR={vi.fn()}
+          terminalWidth={100}
         />
       );
 
@@ -376,12 +387,13 @@ describe('WorktreeOverview', () => {
           activeWorktreeId="main"
           activeRootPath="/repo/main"
           focusedWorktreeId="feature1"
-          expandedWorktreeIds={new Set()}
           visibleStart={1}
           visibleEnd={4}
-          onToggleExpand={vi.fn()}
           onCopyTree={vi.fn()}
           onOpenEditor={vi.fn()}
+          onOpenIssue={vi.fn()}
+          onOpenPR={vi.fn()}
+          terminalWidth={100}
         />
       );
 


### PR DESCRIPTION
## Summary
Fixes worktree card buttons (Copy, Code, Issue, PR) intermittently not responding to clicks. The issue occurred because click region coordinates became stale when cards scrolled in the viewport or when the terminal was resized.

Closes #288

## Changes Made
- Add `listIndex` prop to `WorktreeCard` and `BorderActionButton` to detect position changes from scrolling
- Add `terminalWidth` to `useLayoutEffect` dependency array for resize handling
- Update memo comparison to include `listIndex` for proper re-render triggering
- Add debug logging via `CANOPY_DEBUG_CLICK` environment variable for future diagnostics

## Root Cause
The `useLayoutEffect` in `BorderActionButton` that registers click regions had a dependency array that didn't include anything related to the card's position. When cards scrolled (visibleStart changed), the cards physically moved but the effect didn't re-run, leaving stale coordinates in the click region map.

## Testing
- Run with `CANOPY_DEBUG_CLICK=1` to see click region registration/deregistration logs
- Scroll through worktrees and verify buttons remain clickable
- Resize terminal and verify buttons remain clickable